### PR TITLE
Feature/import neighborhood

### DIFF
--- a/connectivity/access_jobs.sql
+++ b/connectivity/access_jobs.sql
@@ -3,40 +3,38 @@
 -- location: cambridge
 ----------------------------------------
 -- low stress access
-UPDATE  cambridge_census_blocks
+UPDATE  neighborhood_census_blocks
 SET     emp_low_stress = (
             SELECT  SUM(blocks2.jobs)
             FROM    cambridge_census_block_jobs blocks2
             WHERE   EXISTS (
                         SELECT  1
                         FROM    cambridge_connected_census_blocks cb
-                        WHERE   cb.source_blockid10 = cambridge_census_blocks.blockid10
+                        WHERE   cb.source_blockid10 = neighborhood_census_blocks.blockid10
                         AND     cb.target_blockid10 = blocks2.blockid10
                         AND     cb.low_stress
             )
         )
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_census_blocks.geom,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(neighborhood_census_blocks.geom,b.geom)
         );
 
 -- high stress access
-UPDATE  cambridge_census_blocks
+UPDATE  neighborhood_census_blocks
 SET     emp_high_stress = (
             SELECT  SUM(blocks2.jobs)
             FROM    cambridge_census_block_jobs blocks2
             WHERE   EXISTS (
                         SELECT  1
                         FROM    cambridge_connected_census_blocks cb
-                        WHERE   cb.source_blockid10 = cambridge_census_blocks.blockid10
+                        WHERE   cb.source_blockid10 = neighborhood_census_blocks.blockid10
                         AND     cb.target_blockid10 = blocks2.blockid10
             )
         )
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_census_blocks.geom,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(neighborhood_census_blocks.geom,b.geom)
         );

--- a/connectivity/access_population.sql
+++ b/connectivity/access_population.sql
@@ -3,40 +3,38 @@
 -- location: cambridge
 ----------------------------------------
 -- low stress access
-UPDATE  cambridge_census_blocks
+UPDATE  neighborhood_census_blocks
 SET     pop_low_stress = (
             SELECT  SUM(blocks2.pop10)
-            FROM    cambridge_census_blocks blocks2
+            FROM    neighborhood_census_blocks blocks2
             WHERE   EXISTS (
                         SELECT  1
                         FROM    cambridge_connected_census_blocks cb
-                        WHERE   cb.source_blockid10 = cambridge_census_blocks.blockid10
+                        WHERE   cb.source_blockid10 = neighborhood_census_blocks.blockid10
                         AND     cb.target_blockid10 = blocks2.blockid10
                         AND     cb.low_stress
             )
         )
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_census_blocks.geom,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(neighborhood_census_blocks.geom,b.geom)
         );
 
 -- high stress access
-UPDATE  cambridge_census_blocks
+UPDATE  neighborhood_census_blocks
 SET     pop_high_stress = (
             SELECT  SUM(blocks2.pop10)
-            FROM    cambridge_census_blocks blocks2
+            FROM    neighborhood_census_blocks blocks2
             WHERE   EXISTS (
                         SELECT  1
                         FROM    cambridge_connected_census_blocks cb
-                        WHERE   cb.source_blockid10 = cambridge_census_blocks.blockid10
+                        WHERE   cb.source_blockid10 = neighborhood_census_blocks.blockid10
                         AND     cb.target_blockid10 = blocks2.blockid10
             )
         )
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_census_blocks.geom,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(neighborhood_census_blocks.geom,b.geom)
         );

--- a/connectivity/access_schools.sql
+++ b/connectivity/access_schools.sql
@@ -3,39 +3,37 @@
 -- location: cambridge
 ----------------------------------------
 -- low stress access
-UPDATE  cambridge_census_blocks
+UPDATE  neighborhood_census_blocks
 SET     schools_low_stress = (
             SELECT  COUNT(cbs.id)
             FROM    cambridge_connected_census_blocks_schools cbs
-            WHERE   cbs.source_blockid10 = cambridge_census_blocks.blockid10
+            WHERE   cbs.source_blockid10 = neighborhood_census_blocks.blockid10
             AND     cbs.low_stress
         )
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_census_blocks.geom,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary as b
+            WHERE   ST_Intersects(neighborhood_census_blocks.geom,b.geom)
         );
 
 -- high stress access
-UPDATE  cambridge_census_blocks
+UPDATE  neighborhood_census_blocks
 SET     schools_high_stress = (
             SELECT  COUNT(cbs.id)
             FROM    cambridge_connected_census_blocks_schools cbs
-            WHERE   cbs.source_blockid10 = cambridge_census_blocks.blockid10
+            WHERE   cbs.source_blockid10 = neighborhood_census_blocks.blockid10
         )
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_census_blocks.geom,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary as b
+            WHERE   ST_Intersects(neighborhood_census_blocks.geom,b.geom)
         );
 
 -- low stress population shed for schools in neighborhood
 UPDATE  cambridge_schools
 SET     pop_low_stress = (
             SELECT  SUM(cb.pop10)
-            FROM    cambridge_census_blocks cb,
+            FROM    neighborhood_census_blocks cb,
                     cambridge_connected_census_blocks_schools cbs
             WHERE   cb.blockid10 = cbs.source_blockid10
             AND     cambridge_schools.id = cbs.target_school_id
@@ -43,23 +41,21 @@ SET     pop_low_stress = (
         )
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_schools.geom_pt,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary as b
+            WHERE   ST_Intersects(cambridge_schools.geom_pt,b.geom)
         );
 
 -- high stress population shed for schools in neighborhood
 UPDATE  cambridge_schools
 SET     pop_high_stress = (
             SELECT  SUM(cb.pop10)
-            FROM    cambridge_census_blocks cb,
+            FROM    neighborhood_census_blocks cb,
                     cambridge_connected_census_blocks_schools cbs
             WHERE   cb.blockid10 = cbs.source_blockid10
             AND     cambridge_schools.id = cbs.target_school_id
         )
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_schools.geom_pt,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary as b
+            WHERE   ST_Intersects(cambridge_schools.geom_pt,b.geom)
         );

--- a/connectivity/census_block_jobs.sql
+++ b/connectivity/census_block_jobs.sql
@@ -12,16 +12,16 @@
 ----------------------------------------
 
 -- process imported tables
-ALTER TABLE "ma_od_aux_JT00_2014" ALTER COLUMN w_geocode TYPE VARCHAR(15);
-UPDATE "ma_od_aux_JT00_2014" SET w_geocode = rpad(w_geocode,15,'0'); --just in case we lost any trailing zeros
-ALTER TABLE "ma_od_main_JT00_2014" ALTER COLUMN w_geocode TYPE VARCHAR(15);
-UPDATE "ma_od_main_JT00_2014" SET w_geocode = rpad(w_geocode,15,'0'); --just in case we lost any trailing zeros
+ALTER TABLE "state_od_aux_JT00_2014" ALTER COLUMN w_geocode TYPE VARCHAR(15);
+UPDATE "state_od_aux_JT00_2014" SET w_geocode = rpad(w_geocode,15,'0'); --just in case we lost any trailing zeros
+ALTER TABLE "state_od_main_JT00_2014" ALTER COLUMN w_geocode TYPE VARCHAR(15);
+UPDATE "state_od_main_JT00_2014" SET w_geocode = rpad(w_geocode,15,'0'); --just in case we lost any trailing zeros
 
 -- indexes
-CREATE INDEX tidx_auxjtw ON "ma_od_aux_JT00_2014" (w_geocode);
-CREATE INDEX tidx_mainjtw ON "ma_od_main_JT00_2014" (w_geocode);
-ANALYZE "ma_od_aux_JT00_2014" (w_geocode);
-ANALYZE "ma_od_main_JT00_2014" (w_geocode);
+CREATE INDEX tidx_auxjtw ON "state_od_aux_JT00_2014" (w_geocode);
+CREATE INDEX tidx_mainjtw ON "state_od_main_JT00_2014" (w_geocode);
+ANALYZE "state_od_aux_JT00_2014" (w_geocode);
+ANALYZE "state_od_main_JT00_2014" (w_geocode);
 
 -- create combined table
 CREATE TABLE generated.cambridge_census_block_jobs (
@@ -33,13 +33,13 @@ CREATE TABLE generated.cambridge_census_block_jobs (
 -- add blocks of interest
 INSERT INTO generated.cambridge_census_block_jobs (blockid10)
 SELECT  blocks.blockid10
-FROM    cambridge_census_blocks blocks;
+FROM    neighborhood_census_blocks blocks;
 
 -- add main data
 UPDATE  generated.cambridge_census_block_jobs
 SET     jobs = COALESCE((
             SELECT  SUM(j."S000")
-            FROM    "ma_od_main_JT00_2014" j
+            FROM    "state_od_main_JT00_2014" j
             WHERE   j.w_geocode = cambridge_census_block_jobs.blockid10
         ),0);
 
@@ -48,7 +48,7 @@ UPDATE  generated.cambridge_census_block_jobs
 SET     jobs =  jobs +
                 COALESCE((
                     SELECT  SUM(j."S000")
-                    FROM    "ma_od_aux_JT00_2014" j
+                    FROM    "state_od_aux_JT00_2014" j
                     WHERE   j.w_geocode = cambridge_census_block_jobs.blockid10
         ),0);
 
@@ -57,5 +57,5 @@ CREATE INDEX idx_cambridge_blkjobs ON cambridge_census_block_jobs (blockid10);
 ANALYZE cambridge_census_block_jobs (blockid10);
 
 -- drop import tables
--- DROP TABLE IF EXISTS "ma_od_aux_JT00_2014";
--- DROP TABLE IF EXISTS "ma_od_main_JT00_2014";
+-- DROP TABLE IF EXISTS "state_od_aux_JT00_2014";
+-- DROP TABLE IF EXISTS "state_od_main_JT00_2014";

--- a/connectivity/census_block_roads.sql
+++ b/connectivity/census_block_roads.sql
@@ -16,15 +16,9 @@ INSERT INTO generated.cambridge_census_block_roads (
 )
 SELECT  blocks.blockid10,
         ways.road_id
-FROM    cambridge_census_blocks blocks,
+FROM    neighborhood_census_blocks blocks,
         cambridge_ways ways
-WHERE   EXISTS (
-            SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_DWithin(zips.geom, blocks.geom, 11000)
-            AND     zips.zip_code = '02138'
-)
-AND     ST_DWithin(blocks.geom,ways.geom,50);
+WHERE   ST_DWithin(blocks.geom,ways.geom,50);
 
 CREATE INDEX idx_cambridge_censblkrds
 ON generated.cambridge_census_block_roads (blockid10,road_id);

--- a/connectivity/census_blocks.sql
+++ b/connectivity/census_blocks.sql
@@ -1,19 +1,19 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 -- code to be run on table that has
 -- been imported directly from US Census
 -- blkpophu file
 ----------------------------------------
 
-ALTER TABLE cambridge_census_blocks ADD COLUMN pop_low_stress INT;
-ALTER TABLE cambridge_census_blocks ADD COLUMN pop_high_stress INT;
-ALTER TABLE cambridge_census_blocks ADD COLUMN emp_low_stress INT;
-ALTER TABLE cambridge_census_blocks ADD COLUMN emp_high_stress INT;
-ALTER TABLE cambridge_census_blocks ADD COLUMN schools_low_stress INT;
-ALTER TABLE cambridge_census_blocks ADD COLUMN schools_high_stress INT;
-ALTER TABLE cambridge_census_blocks ADD COLUMN rec_low_stress INT;
-ALTER TABLE cambridge_census_blocks ADD COLUMN rec_high_stress INT;
+ALTER TABLE neighborhood_census_blocks ADD COLUMN pop_low_stress INT;
+ALTER TABLE neighborhood_census_blocks ADD COLUMN pop_high_stress INT;
+ALTER TABLE neighborhood_census_blocks ADD COLUMN emp_low_stress INT;
+ALTER TABLE neighborhood_census_blocks ADD COLUMN emp_high_stress INT;
+ALTER TABLE neighborhood_census_blocks ADD COLUMN schools_low_stress INT;
+ALTER TABLE neighborhood_census_blocks ADD COLUMN schools_high_stress INT;
+ALTER TABLE neighborhood_census_blocks ADD COLUMN rec_low_stress INT;
+ALTER TABLE neighborhood_census_blocks ADD COLUMN rec_high_stress INT;
 
-CREATE INDEX idx_cambridge_blocks10 ON cambridge_census_blocks (blockid10);
-ANALYZE cambridge_census_blocks (blockid10);
+CREATE INDEX idx_neighborhood_blocks10 ON neighborhood_census_blocks (blockid10);
+ANALYZE neighborhood_census_blocks (blockid10);

--- a/connectivity/connected_census_blocks.sql
+++ b/connectivity/connected_census_blocks.sql
@@ -21,13 +21,12 @@ SELECT  source_block.blockid10,
         target_block.blockid10,
         'f'::BOOLEAN,
         't'::BOOLEAN
-FROM    cambridge_census_blocks source_block,
-        cambridge_census_blocks target_block
+FROM    neighborhood_census_blocks source_block,
+        neighborhood_census_blocks target_block
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(source_block.geom,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(source_block.geom,b.geom)
         )
 AND     source_block.geom <#> target_block.geom < 11000
 AND     EXISTS (

--- a/connectivity/connected_census_blocks_schools.sql
+++ b/connectivity/connected_census_blocks_schools.sql
@@ -21,13 +21,12 @@ SELECT  blocks.blockid10,
         schools.id,
         'f'::BOOLEAN,
         't'::BOOLEAN
-FROM    cambridge_census_blocks blocks,
+FROM    neighborhood_census_blocks blocks,
         cambridge_schools schools
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(blocks.geom,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(blocks.geom,b.geom)
         )
 AND     blocks.geom <#> schools.geom_pt < 11000
 AND     EXISTS (

--- a/connectivity/overall_scores.sql
+++ b/connectivity/overall_scores.sql
@@ -22,12 +22,11 @@ SELECT  'Population',
         regexp_replace('Total population accessible by low stress
             expressed as the median of all census blocks in the
             neighborhood','\n\s+',' ')
-FROM    cambridge_census_blocks
+FROM    neighborhood_census_blocks
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_census_blocks.geom,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(neighborhood_census_blocks.geom,b.geom)
         );
 
 -- median pop access high stress
@@ -40,12 +39,11 @@ SELECT  'Population',
         regexp_replace('Total population accessible by high stress
             expressed as the median of all census blocks in the
             neighborhood','\n\s+',' ')
-FROM    cambridge_census_blocks
+FROM    neighborhood_census_blocks
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_census_blocks.geom,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(neighborhood_census_blocks.geom,b.geom)
         );
 
 -- median pop access ratio
@@ -59,12 +57,11 @@ SELECT  'Population',
             to population accessible overall, expressed as
             the median of all census blocks in the
             neighborhood','\n\s+',' ')
-FROM    cambridge_census_blocks
+FROM    neighborhood_census_blocks
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_census_blocks.geom,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(neighborhood_census_blocks.geom,b.geom)
         );
 
 -- 70th percentile pop access ratio
@@ -78,12 +75,11 @@ SELECT  'Population',
             to population accessible overall, expressed as
             the 70th percentile of all census blocks in the
             neighborhood','\n\s+',' ')
-FROM    cambridge_census_blocks
+FROM    neighborhood_census_blocks
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_census_blocks.geom,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(neighborhood_census_blocks.geom,b.geom)
         );
 
 -- avg pop access ratio
@@ -97,12 +93,11 @@ SELECT  'Population',
             to population accessible overall, expressed as
             the average of all census blocks in the
             neighborhood','\n\s+',' ')
-FROM    cambridge_census_blocks
+FROM    neighborhood_census_blocks
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_census_blocks.geom,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(neighborhood_census_blocks.geom,b.geom)
         );
 
 -- median jobs access low stress
@@ -115,12 +110,11 @@ SELECT  'Employment',
         regexp_replace('Total jobs accessible by low stress
             expressed as the median of all census blocks in the
             neighborhood','\n\s+',' ')
-FROM    cambridge_census_blocks
+FROM    neighborhood_census_blocks
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_census_blocks.geom,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(neighborhood_census_blocks.geom,b.geom)
         );
 
 -- median jobs access high stress
@@ -133,12 +127,11 @@ SELECT  'Employment',
         regexp_replace('Total jobs accessible by high stress
             expressed as the median of all census blocks in the
             neighborhood','\n\s+',' ')
-FROM    cambridge_census_blocks
+FROM    neighborhood_census_blocks
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_census_blocks.geom,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(neighborhood_census_blocks.geom,b.geom)
         );
 
 -- median jobs access ratio
@@ -152,12 +145,11 @@ SELECT  'Employment',
             to employment accessible overall, expressed as
             the median of all census blocks in the
             neighborhood','\n\s+',' ')
-FROM    cambridge_census_blocks
+FROM    neighborhood_census_blocks
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_census_blocks.geom,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(neighborhood_census_blocks.geom,b.geom)
         );
 
 -- 70th percentile jobs access ratio
@@ -171,12 +163,11 @@ SELECT  'Employment',
             to employment accessible overall, expressed as
             the 70th percentile of all census blocks in the
             neighborhood','\n\s+',' ')
-FROM    cambridge_census_blocks
+FROM    neighborhood_census_blocks
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_census_blocks.geom,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(neighborhood_census_blocks.geom,b.geom)
         );
 
 -- avg jobs access ratio
@@ -190,12 +181,11 @@ SELECT  'Employment',
             to employment accessible overall, expressed as
             the average of all census blocks in the
             neighborhood','\n\s+',' ')
-FROM    cambridge_census_blocks
+FROM    neighborhood_census_blocks
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_census_blocks.geom,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(neighborhood_census_blocks.geom,b.geom)
         );
 
 -- median schools access low stress
@@ -208,12 +198,11 @@ SELECT  'Schools',
         regexp_replace('Number of schools accessible by low stress
             expressed as an average of all census blocks in the
             neighborhood','\n\s+',' ')
-FROM    cambridge_census_blocks
+FROM    neighborhood_census_blocks
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_census_blocks.geom,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(neighborhood_census_blocks.geom,b.geom)
         );
 
 -- median schools access high stress
@@ -226,12 +215,11 @@ SELECT  'Schools',
         regexp_replace('Number of schools accessible by high stress
             expressed as an average of all census blocks in the
             neighborhood','\n\s+',' ')
-FROM    cambridge_census_blocks
+FROM    neighborhood_census_blocks
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_census_blocks.geom,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(neighborhood_census_blocks.geom,b.geom)
         );
 
 -- school low stress pop shed access
@@ -247,9 +235,8 @@ SELECT  'Schools',
 FROM    cambridge_schools
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_schools.geom_pt,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(cambridge_schools.geom_pt,b.geom)
         );
 
 -- school high stress pop shed access
@@ -265,9 +252,8 @@ SELECT  'Schools',
 FROM    cambridge_schools
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_schools.geom_pt,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(cambridge_schools.geom_pt,b.geom)
         );
 
 -- school pop shed access ratio
@@ -284,7 +270,6 @@ SELECT  'Schools',
 FROM    cambridge_schools
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_schools.geom_pt,zips.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(cambridge_schools.geom_pt,b.geom)
         );

--- a/connectivity/reachable_roads_high_stress.sql
+++ b/connectivity/reachable_roads_high_stress.sql
@@ -35,9 +35,8 @@ FROM    cambridge_ways r1,
         ) sheds
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(zips.geom,r1.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(b.geom,r1.geom)
 )
 AND     r1.road_id = v1.road_id
 AND     v2.vert_id = sheds.node;

--- a/connectivity/reachable_roads_low_stress.sql
+++ b/connectivity/reachable_roads_low_stress.sql
@@ -36,9 +36,8 @@ FROM    cambridge_ways r1,
         ) sheds
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(zips.geom,r1.geom)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_Intersects(b.geom,r1.geom)
 )
 AND     r1.road_id = v1.road_id
 AND     v2.vert_id = sheds.node;

--- a/connectivity/school_roads.sql
+++ b/connectivity/school_roads.sql
@@ -21,9 +21,8 @@ FROM    cambridge_schools schools,
         cambridge_ways ways
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_DWithin(zips.geom, schools.geom_pt, 11000)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_DWithin(b.geom, schools.geom_pt, 11000)
         )
 AND     schools.geom_poly IS NOT NULL
 AND     ST_DWithin(schools.geom_poly,ways.geom,50);
@@ -43,9 +42,8 @@ SELECT  schools.id,
 FROM    cambridge_schools schools
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_DWithin(zips.geom, schools.geom_pt, 11000)
-            AND     zips.zip_code = '02138'
+            FROM    neighborhood_boundary AS b
+            WHERE   ST_DWithin(b.geom, schools.geom_pt, 11000)
         )
 AND     NOT EXISTS (
             SELECT  1

--- a/import_jobs.sh
+++ b/import_jobs.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+NB_POSTGRESQL_HOST="${NB_POSTGRESQL_HOST:-127.0.0.1}"
+NB_POSTGRESQL_DB="${NB_POSTGRESQL_DB:-pfb}"
+NB_POSTGRESQL_USER="${NB_POSTGRESQL_USER:-gis}"
+NB_POSTGRESQL_PASSWORD="${NB_POSTGRESQL_PASSWORD:-gis}"
+
+
+set -e
+
+if [[ -n "${PFB_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+"
+Usage: $(basename "$0") <state_abbrev>
+
+Import state jobs data into postgres database.
+
+Requires passing the state FIPS abbrev that the neighborhood boundary is found in. e.g. MA for Massachussetts
+    See: https://www.census.gov/geo/reference/ansi_statetables.html
+
+Optional ENV vars:
+
+NB_POSTGRESQL_HOST - Default: 127.0.0.1
+NB_POSTGRESQL_DB - Default: pfb
+NB_POSTGRESQL_USER - Default: gis
+NB_POSTGRESQL_PASSWORD - Default: gis
+
+"
+}
+
+function import_job_data() {
+    NB_TEMPDIR=`mktemp -d`
+    NB_STATE_ABBREV="${1}"
+    NB_DATA_TYPE="${2-main}"    # Either 'main' or 'aux'
+    NB_JOB_FILENAME="${NB_STATE_ABBREV}_od_${NB_DATA_TYPE}_JT00_2014.csv"
+
+    wget -P "${NB_TEMPDIR}" "http://lehd.ces.census.gov/data/lodes/LODES7/${NB_STATE_ABBREV}/od/${NB_JOB_FILENAME}.gz"
+    gunzip -c "${NB_TEMPDIR}/${NB_JOB_FILENAME}.gz" > "${NB_TEMPDIR}/${NB_JOB_FILENAME}"
+
+    # Import to postgresql
+    psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+        -c "
+CREATE TABLE IF NOT EXISTS \"state_od_${NB_DATA_TYPE}_JT00_2014\" (
+    w_geocode varchar(15),
+    h_geocode varchar(15),
+    \"S000\" integer,
+    \"SA01\" integer,
+    \"SA02\" integer,
+    \"SA03\" integer,
+    \"SE01\" integer,
+    \"SE02\" integer,
+    \"SE03\" integer,
+    \"SI01\" integer,
+    \"SI02\" integer,
+    \"SI03\" integer,
+    createdate VARCHAR(32)
+);"
+    psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+        -c "TRUNCATE TABLE \"state_od_${NB_DATA_TYPE}_JT00_2014\";"
+
+    # Load data
+    # Dir and files must be world readable/executable for postgres to use copy command
+    chmod -R 775 "${NB_TEMPDIR}"
+    psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+        -c "COPY \"state_od_${NB_DATA_TYPE}_JT00_2014\"(w_geocode, h_geocode, \"S000\", \"SA01\", \"SA02\", \"SA03\", \"SE01\", \"SE02\", \"SE03\", \"SI01\", \"SI02\", \"SI03\", createdate) FROM '${NB_TEMPDIR}/${NB_JOB_FILENAME}' DELIMITER ',' CSV HEADER;"
+
+    # Remove NB_TEMPDIR
+    rm -rf "${NB_TEMPDIR}"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ] || [ -z "${1:-}" ]
+    then
+        usage
+    else
+        NB_STATE_ABBREV="${1}"
+
+        import_job_data "${NB_STATE_ABBREV}" "main"
+        import_job_data "${NB_STATE_ABBREV}" "aux"
+
+    fi
+fi

--- a/import_neighborhood.sh
+++ b/import_neighborhood.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+NB_INPUT_SRID="${NB_INPUT_SRID:-4326}"
+NB_OUTPUT_SRID="${NB_OUTPUT_SRID:-4326}"
+NB_BOUNDARY_BUFFER="${NB_BOUNDARY_BUFFER:-0}"
+NB_POSTGRESQL_HOST="${NB_POSTGRESQL_HOST:-127.0.0.1}"
+NB_POSTGRESQL_DB="${NB_POSTGRESQL_DB:-pfb}"
+NB_POSTGRESQL_USER="${NB_POSTGRESQL_USER:-gis}"
+NB_POSTGRESQL_PASSWORD="${NB_POSTGRESQL_PASSWORD:-gis}"
+
+NB_TEMPDIR=`mktemp -d`
+
+set -e
+
+if [[ -n "${PFB_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+"
+Usage: $(basename "$0") <neighborhood_boundary_shapefile> <neighborhood_tiger_state_id>
+
+Import neighborhood boundary to postgres database, overwriting any existing boundary
+
+Requires passing path (relative or absolute) to the neighborhood boundary shapefile.
+Requires passing the state FIPS ID that the neighborhood boundary is found in. e.g. MA is 25
+    See: https://www.census.gov/geo/reference/ansi_statetables.html
+
+Optional ENV vars:
+
+NB_INPUT_SRID - Default: 4326
+NB_OUTPUT_SRID - Default: 4326
+NB_BOUNDARY_BUFFER - Default: 0 (Units is units of NB_OUTPUT_SRID)
+NB_POSTGRESQL_HOST - Default: 127.0.0.1
+NB_POSTGRESQL_DB - Default: pfb
+NB_POSTGRESQL_USER - Default: gis
+NB_POSTGRESQL_PASSWORD - Default: gis
+
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ] || [ -z "${1:-}" ]
+    then
+        usage
+    else
+        NB_BOUNDARY_FILE="${1}"
+        NB_STATE_FIPS="${2}"
+
+        # Import neighborhood boundary
+        shp2pgsql -d -s "${NB_INPUT_SRID}":"${NB_OUTPUT_SRID}" "${NB_BOUNDARY_FILE}" neighborhood_boundary \
+            | psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}"
+
+        # Get blocks for the state requested
+        NB_BLOCK_FILENAME="tabblock2010_${NB_STATE_FIPS}_pophu"
+        wget -P "${NB_TEMPDIR}" "http://www2.census.gov/geo/tiger/TIGER2010BLKPOPHU/${NB_BLOCK_FILENAME}.zip"
+        unzip "${NB_TEMPDIR}/${NB_BLOCK_FILENAME}.zip" -d "${NB_TEMPDIR}"
+
+        # Import block shapefile
+        echo "START: Importing blocks"
+        shp2pgsql -d -s 4326:"${NB_OUTPUT_SRID}" "${NB_TEMPDIR}/${NB_BLOCK_FILENAME}.shp" neighborhood_census_blocks \
+            | psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" > /dev/null
+        echo "DONE: Importing blocks"
+
+        # Only keep blocks in boundary+buffer
+        psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+            -c "DELETE FROM neighborhood_census_blocks AS blocks USING neighborhood_boundary AS boundary WHERE NOT ST_DWithin(blocks.geom, boundary.geom, ${NB_BOUNDARY_BUFFER});"
+
+        # Remove NB_TEMPDIR
+        rm -rf "${NB_TEMPDIR}"
+    fi
+fi

--- a/import_osm.sh
+++ b/import_osm.sh
@@ -2,176 +2,177 @@
 
 cd `dirname $0`
 
-# vars
-DBHOST='127.0.0.1'
-DBNAME='pfb'
-OSMPREFIX='cambridge'
-OSMFILE='/vagrant/data/cambridge.osm'
+NB_POSTGRESQL_HOST="${NB_POSTGRESQL_HOST:-127.0.0.1}"
+NB_POSTGRESQL_DB="${NB_POSTGRESQL_DB:-pfb}"
+NB_POSTGRESQL_USER="${NB_POSTGRESQL_USER:-gis}"
+NB_POSTGRESQL_PASSWORD="${NB_POSTGRESQL_PASSWORD:-gis}"
+NB_OSMPREFIX="${NB_OSMPREFIX:-cambridge}"
+NB_OSMFILE="${NB_OSMFILE:-/vagrant/data/cambridge.osm}"
 
 # drop old tables
 echo 'Dropping old tables'
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_ways;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_ways_intersections;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_relations_ways;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_osm_nodes;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_osm_relations;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_osm_way_classes;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_osm_way_tags;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_osm_way_types;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS scratch.${OSMPREFIX}_cycwys_ways;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS scratch.${OSMPREFIX}_cycwys_ways_vertices_pgr;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS scratch.${OSMPREFIX}_cycwys_relations_ways;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS scratch.${OSMPREFIX}_cycwys_osm_nodes;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS scratch.${OSMPREFIX}_cycwys_osm_relations;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS scratch.${OSMPREFIX}_cycwys_osm_way_classes;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS scratch.${OSMPREFIX}_cycwys_osm_way_tags;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS scratch.${OSMPREFIX}_cycwys_osm_way_types;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_ways;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_ways_intersections;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_relations_ways;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_osm_nodes;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_osm_relations;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_osm_way_classes;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_osm_way_tags;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_osm_way_types;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "DROP TABLE IF EXISTS scratch.${NB_OSMPREFIX}_cycwys_ways;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "DROP TABLE IF EXISTS scratch.${NB_OSMPREFIX}_cycwys_ways_vertices_pgr;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "DROP TABLE IF EXISTS scratch.${NB_OSMPREFIX}_cycwys_relations_ways;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "DROP TABLE IF EXISTS scratch.${NB_OSMPREFIX}_cycwys_osm_nodes;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "DROP TABLE IF EXISTS scratch.${NB_OSMPREFIX}_cycwys_osm_relations;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "DROP TABLE IF EXISTS scratch.${NB_OSMPREFIX}_cycwys_osm_way_classes;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "DROP TABLE IF EXISTS scratch.${NB_OSMPREFIX}_cycwys_osm_way_tags;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "DROP TABLE IF EXISTS scratch.${NB_OSMPREFIX}_cycwys_osm_way_types;"
 
 # import the osm with highways
 osm2pgrouting \
-  -f $OSMFILE \
-  -h $DBHOST \
-  --dbname ${DBNAME} \
-  --username gis \
+  -f $NB_OSMFILE \
+  -h $NB_POSTGRESQL_HOST \
+  --dbname ${NB_POSTGRESQL_DB} \
+  --username ${NB_POSTGRESQL_USER} \
   --schema received \
-  --prefix ${OSMPREFIX}_ \
+  --prefix ${NB_OSMPREFIX}_ \
   --conf ./mapconfig_highway.xml \
   --clean
 
 # import the osm with cycleways that the above misses (bug in osm2pgrouting)
 osm2pgrouting \
-  -f $OSMFILE \
-  -h $DBHOST \
-  --dbname ${DBNAME} \
-  --username gis \
+  -f $NB_OSMFILE \
+  -h $NB_POSTGRESQL_HOST \
+  --dbname ${NB_POSTGRESQL_DB} \
+  --username ${NB_POSTGRESQL_USER} \
   --schema scratch \
-  --prefix ${OSMPREFIX}_cycwys_ \
+  --prefix ${NB_OSMPREFIX}_cycwys_ \
   --conf ./mapconfig_cycleway.xml \
   --clean
 
 # rename a few tables
 echo 'Renaming tables'
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE received.${OSMPREFIX}_ways_vertices_pgr RENAME TO ${OSMPREFIX}_ways_intersections;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE received.${OSMPREFIX}_ways_intersections RENAME CONSTRAINT vertex_id TO ${OSMPREFIX}_vertex_id;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE received.osm_nodes RENAME TO ${OSMPREFIX}_osm_nodes;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE received.${OSMPREFIX}_osm_nodes RENAME CONSTRAINT node_id TO ${OSMPREFIX}_node_id;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE received.osm_relations RENAME TO ${OSMPREFIX}_osm_relations;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE received.osm_way_classes RENAME TO ${OSMPREFIX}_osm_way_classes;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE received.${OSMPREFIX}_osm_way_classes RENAME CONSTRAINT osm_way_classes_pkey TO ${OSMPREFIX}_osm_way_classes_pkey;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE received.osm_way_tags RENAME TO ${OSMPREFIX}_osm_way_tags;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE received.osm_way_types RENAME TO ${OSMPREFIX}_osm_way_types;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE received.${OSMPREFIX}_osm_way_types RENAME CONSTRAINT osm_way_types_pkey TO ${OSMPREFIX}_osm_way_types_pkey;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE scratch.${OSMPREFIX}_cycwys_ways_vertices_pgr RENAME CONSTRAINT vertex_id TO ${OSMPREFIX}_vertex_id;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE scratch.osm_nodes RENAME TO ${OSMPREFIX}_cycwys_osm_nodes;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE scratch.${OSMPREFIX}_cycwys_osm_nodes RENAME CONSTRAINT node_id TO ${OSMPREFIX}_node_id;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE scratch.osm_relations RENAME TO ${OSMPREFIX}_cycwys_osm_relations;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE scratch.osm_way_classes RENAME TO ${OSMPREFIX}_cycwys_osm_way_classes;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE scratch.${OSMPREFIX}_cycwys_osm_way_classes RENAME CONSTRAINT osm_way_classes_pkey TO ${OSMPREFIX}_osm_way_classes_pkey;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE scratch.osm_way_tags RENAME TO ${OSMPREFIX}_cycwys_osm_way_tags;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE scratch.osm_way_types RENAME TO ${OSMPREFIX}_cycwys_osm_way_types;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE scratch.${OSMPREFIX}_cycwys_osm_way_types RENAME CONSTRAINT osm_way_types_pkey TO ${OSMPREFIX}_osm_way_types_pkey;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE received.${NB_OSMPREFIX}_ways_vertices_pgr RENAME TO ${NB_OSMPREFIX}_ways_intersections;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE received.${NB_OSMPREFIX}_ways_intersections RENAME CONSTRAINT vertex_id TO ${NB_OSMPREFIX}_vertex_id;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE received.osm_nodes RENAME TO ${NB_OSMPREFIX}_osm_nodes;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE received.${NB_OSMPREFIX}_osm_nodes RENAME CONSTRAINT node_id TO ${NB_OSMPREFIX}_node_id;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE received.osm_relations RENAME TO ${NB_OSMPREFIX}_osm_relations;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE received.osm_way_classes RENAME TO ${NB_OSMPREFIX}_osm_way_classes;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE received.${NB_OSMPREFIX}_osm_way_classes RENAME CONSTRAINT osm_way_classes_pkey TO ${NB_OSMPREFIX}_osm_way_classes_pkey;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE received.osm_way_tags RENAME TO ${NB_OSMPREFIX}_osm_way_tags;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE received.osm_way_types RENAME TO ${NB_OSMPREFIX}_osm_way_types;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE received.${NB_OSMPREFIX}_osm_way_types RENAME CONSTRAINT osm_way_types_pkey TO ${NB_OSMPREFIX}_osm_way_types_pkey;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE scratch.${NB_OSMPREFIX}_cycwys_ways_vertices_pgr RENAME CONSTRAINT vertex_id TO ${NB_OSMPREFIX}_vertex_id;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE scratch.osm_nodes RENAME TO ${NB_OSMPREFIX}_cycwys_osm_nodes;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE scratch.${NB_OSMPREFIX}_cycwys_osm_nodes RENAME CONSTRAINT node_id TO ${NB_OSMPREFIX}_node_id;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE scratch.osm_relations RENAME TO ${NB_OSMPREFIX}_cycwys_osm_relations;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE scratch.osm_way_classes RENAME TO ${NB_OSMPREFIX}_cycwys_osm_way_classes;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE scratch.${NB_OSMPREFIX}_cycwys_osm_way_classes RENAME CONSTRAINT osm_way_classes_pkey TO ${NB_OSMPREFIX}_osm_way_classes_pkey;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE scratch.osm_way_tags RENAME TO ${NB_OSMPREFIX}_cycwys_osm_way_tags;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE scratch.osm_way_types RENAME TO ${NB_OSMPREFIX}_cycwys_osm_way_types;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE scratch.${NB_OSMPREFIX}_cycwys_osm_way_types RENAME CONSTRAINT osm_way_types_pkey TO ${NB_OSMPREFIX}_osm_way_types_pkey;"
 
 # import full osm to fill out additional data needs
 # not met by osm2pgrouting
 
 # drop old tables
 echo 'Dropping old tables'
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_osm_full_line;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_osm_full_point;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_osm_full_polygon;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_osm_full_roads;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_osm_full_line;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_osm_full_point;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_osm_full_polygon;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_osm_full_roads;"
 
 # import
 osm2pgsql \
-  --host "${DBHOST}" \
-  --username gis \
+  --host "${NB_POSTGRESQL_HOST}" \
+  --username ${NB_POSTGRESQL_USER} \
   --port 5432 \
   --create \
-  --database "${DBNAME}" \
-  --prefix "${OSMPREFIX}_osm_full" \
+  --database "${NB_POSTGRESQL_DB}" \
+  --prefix "${NB_OSMPREFIX}_osm_full" \
   --proj 2249 \
   --style ./pfb.style \
-  "${OSMFILE}"
+  "${NB_OSMFILE}"
 
 # move the full osm tables to the received schema
 echo 'Moving tables to received schema'
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE generated.${OSMPREFIX}_osm_full_line SET SCHEMA received;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE generated.${OSMPREFIX}_osm_full_point SET SCHEMA received;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE generated.${OSMPREFIX}_osm_full_polygon SET SCHEMA received;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "ALTER TABLE generated.${OSMPREFIX}_osm_full_roads SET SCHEMA received;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE generated.${NB_OSMPREFIX}_osm_full_line SET SCHEMA received;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE generated.${NB_OSMPREFIX}_osm_full_point SET SCHEMA received;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE generated.${NB_OSMPREFIX}_osm_full_polygon SET SCHEMA received;"
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
+  -c "ALTER TABLE generated.${NB_OSMPREFIX}_osm_full_roads SET SCHEMA received;"
 
 # process tables
 echo 'Updating field names'
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./prepare_tables.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./prepare_tables.sql
 echo 'Setting values on road segments'
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./one_way.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./functional_class.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./paths.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./speed_limit.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./width_ft.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./lanes.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./park.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./bike_infra.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./one_way.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./functional_class.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./paths.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./speed_limit.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./width_ft.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./lanes.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./park.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./bike_infra.sql
 echo 'Setting values on intersections'
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./legs.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./signalized.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./stops.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./legs.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./signalized.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./stops.sql
 echo 'Calculating stress'
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./stress_motorway-trunk.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./stress_primary.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./stress_secondary.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./stress_tertiary.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./stress_residential.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./stress_living_street.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./stress_track.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./stress_path.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./stress_one_way_reset.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./stress_motorway-trunk_ints.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./stress_primary_ints.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./stress_secondary_ints.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./stress_tertiary_ints.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./stress_lesser_ints.sql
-psql -h $DBHOST -U gis -d ${DBNAME} -f ./stress_link_ints.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./stress_motorway-trunk.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./stress_primary.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./stress_secondary.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./stress_tertiary.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./stress_residential.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./stress_living_street.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./stress_track.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./stress_path.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./stress_one_way_reset.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./stress_motorway-trunk_ints.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./stress_primary_ints.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./stress_secondary_ints.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./stress_tertiary_ints.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./stress_lesser_ints.sql
+psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} -f ./stress_link_ints.sql

--- a/run_connectivity.sh
+++ b/run_connectivity.sh
@@ -43,9 +43,6 @@ OSMPREFIX='cambridge'
   -f connectivity/school_roads.sql
 
 /usr/bin/time -v psql -h "${DBHOST}" -U gis -d "${DBNAME}" \
-  -f connectivity/school_roads.sql
-
-/usr/bin/time -v psql -h "${DBHOST}" -U gis -d "${DBNAME}" \
   -f connectivity/connected_census_blocks_schools.sql
 
 /usr/bin/time -v psql -h "${DBHOST}" -U gis -d "${DBNAME}" \


### PR DESCRIPTION
## Overview

This PR allows the analysis to be run on any arbitrary boundary.

Adds two scripts to the project root. See script usage notes for additional details including configuration options:

`import_neighborhood.sh`: Imports a shapefile from disk into the `neighborhood_boundary` table, and then imports all of the census blocks to `neighborhood_census_blocks` from the state specified. Once imported, deletes all census blocks from the imported table that are not in the boundary + buffer specified by script arguments. 

`import_jobs.sh`: Imports 2014 state job data for the state specified to the two tables `state_od_main_JT00_2014` and `state_od_aux_JT00_2014`. This data is used in the network analysis.

In addition to the data import scripts, this updates the sql scripts in the connectivity analysis to reference the new tables created rather than the original cambridge specific tables.

The analysis benefits from an ~2-3x speedup. The cambridge analysis runs in slightly < 5hrs. I ran the entire analysis using this branch, and diffed the output log. There were no changes relative to `master`.
