### PR TITLE
Feature/generalize scripts

### DIFF
--- a/bike_infra.sql
+++ b/bike_infra.sql
@@ -1,17 +1,17 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-UPDATE  cambridge_ways SET ft_bike_infra = NULL, tf_bike_infra = NULL;
+UPDATE  neighborhood_ways SET ft_bike_infra = NULL, tf_bike_infra = NULL;
 
 ----------------------
 -- ft direction
 ----------------------
 -- sharrow
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     ft_bike_infra = 'sharrow'
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND (
             osm."cycleway:both" = 'shared_lane'
         OR  (COALESCE(one_way_car,'ft') = 'ft' AND osm.cycleway = 'shared_lane')
@@ -20,10 +20,10 @@ AND (
 );
 
 -- lane
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     ft_bike_infra = 'lane'
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND (
             osm."cycleway:both" = 'lane'
         OR  (COALESCE(one_way_car,'ft') = 'ft' AND osm.cycleway = 'lane')
@@ -34,10 +34,10 @@ AND (
 );
 
 -- buffered lane
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     ft_bike_infra = 'buffered_lane'
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND (
             osm."cycleway:both" = 'buffered_lane'
         OR  (COALESCE(one_way_car,'ft') = 'ft' AND osm.cycleway = 'buffered_lane')
@@ -53,10 +53,10 @@ AND (
 );
 
 -- track
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     ft_bike_infra = 'track'
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND (
             osm."cycleway:both" = 'track'
         OR  (osm."cycleway:right" = 'track' AND osm."oneway:bicycle" = 'no')
@@ -74,10 +74,10 @@ AND (
 -- tf direction
 ----------------------
 -- sharrow
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     tf_bike_infra = 'sharrow'
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND (
             osm."cycleway:both" = 'shared_lane'
         OR  (COALESCE(one_way_car,'tf') = 'tf' AND osm.cycleway = 'shared_lane')
@@ -86,10 +86,10 @@ AND (
 );
 
 -- lane
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     tf_bike_infra = 'lane'
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND (
             osm."cycleway:both" = 'lane'
         OR  (COALESCE(one_way_car,'tf') = 'tf' AND osm.cycleway = 'lane')
@@ -100,10 +100,10 @@ AND (
 );
 
 -- buffered lane
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     tf_bike_infra = 'buffered_lane'
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND (
             osm."cycleway:both" = 'buffered_lane'
         OR  (COALESCE(one_way_car,'tf') = 'tf' AND osm.cycleway = 'buffered_lane')
@@ -119,10 +119,10 @@ AND (
 );
 
 -- track
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     tf_bike_infra = 'track'
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND (
             osm."cycleway:both" = 'track'
         OR  (osm."cycleway:left" = 'track' AND osm."oneway:bicycle" = 'no')
@@ -136,17 +136,17 @@ AND (
 );
 
 -- update one_way based on bike infra
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     one_way = NULL;
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     one_way = one_way_car
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     one_way_car = 'ft'
 AND     NOT (tf_bike_infra IS NOT NULL OR COALESCE(osm."oneway:bicycle",'yes') = 'no');
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     one_way = one_way_car
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     one_way_car = 'tf'
 AND     NOT (ft_bike_infra IS NOT NULL OR COALESCE(osm."oneway:bicycle",'yes') = 'no');

--- a/connectivity/access_jobs.sql
+++ b/connectivity/access_jobs.sql
@@ -3,6 +3,7 @@
 -- location: neighborhood
 ----------------------------------------
 -- low stress access
+UPDATE neighborhood_census_blocks SET emp_low_stress = NULL;
 UPDATE  neighborhood_census_blocks
 SET     emp_low_stress = (
             SELECT  SUM(blocks2.jobs)
@@ -22,6 +23,7 @@ WHERE   EXISTS (
         );
 
 -- high stress access
+UPDATE neighborhood_census_blocks SET emp_high_stress = NULL;
 UPDATE  neighborhood_census_blocks
 SET     emp_high_stress = (
             SELECT  SUM(blocks2.jobs)

--- a/connectivity/access_jobs.sql
+++ b/connectivity/access_jobs.sql
@@ -1,15 +1,15 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
 -- low stress access
 UPDATE  neighborhood_census_blocks
 SET     emp_low_stress = (
             SELECT  SUM(blocks2.jobs)
-            FROM    cambridge_census_block_jobs blocks2
+            FROM    neighborhood_census_block_jobs blocks2
             WHERE   EXISTS (
                         SELECT  1
-                        FROM    cambridge_connected_census_blocks cb
+                        FROM    neighborhood_connected_census_blocks cb
                         WHERE   cb.source_blockid10 = neighborhood_census_blocks.blockid10
                         AND     cb.target_blockid10 = blocks2.blockid10
                         AND     cb.low_stress
@@ -25,10 +25,10 @@ WHERE   EXISTS (
 UPDATE  neighborhood_census_blocks
 SET     emp_high_stress = (
             SELECT  SUM(blocks2.jobs)
-            FROM    cambridge_census_block_jobs blocks2
+            FROM    neighborhood_census_block_jobs blocks2
             WHERE   EXISTS (
                         SELECT  1
-                        FROM    cambridge_connected_census_blocks cb
+                        FROM    neighborhood_connected_census_blocks cb
                         WHERE   cb.source_blockid10 = neighborhood_census_blocks.blockid10
                         AND     cb.target_blockid10 = blocks2.blockid10
             )

--- a/connectivity/access_population.sql
+++ b/connectivity/access_population.sql
@@ -3,6 +3,7 @@
 -- location: neighborhood
 ----------------------------------------
 -- low stress access
+UPDATE neighborhood_census_blocks SET pop_low_stress = NULL;
 UPDATE  neighborhood_census_blocks
 SET     pop_low_stress = (
             SELECT  SUM(blocks2.pop10)
@@ -22,6 +23,7 @@ WHERE   EXISTS (
         );
 
 -- high stress access
+UPDATE neighborhood_census_blocks SET pop_high_stress = NULL;
 UPDATE  neighborhood_census_blocks
 SET     pop_high_stress = (
             SELECT  SUM(blocks2.pop10)

--- a/connectivity/access_population.sql
+++ b/connectivity/access_population.sql
@@ -1,6 +1,6 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
 -- low stress access
 UPDATE  neighborhood_census_blocks
@@ -9,7 +9,7 @@ SET     pop_low_stress = (
             FROM    neighborhood_census_blocks blocks2
             WHERE   EXISTS (
                         SELECT  1
-                        FROM    cambridge_connected_census_blocks cb
+                        FROM    neighborhood_connected_census_blocks cb
                         WHERE   cb.source_blockid10 = neighborhood_census_blocks.blockid10
                         AND     cb.target_blockid10 = blocks2.blockid10
                         AND     cb.low_stress
@@ -28,7 +28,7 @@ SET     pop_high_stress = (
             FROM    neighborhood_census_blocks blocks2
             WHERE   EXISTS (
                         SELECT  1
-                        FROM    cambridge_connected_census_blocks cb
+                        FROM    neighborhood_connected_census_blocks cb
                         WHERE   cb.source_blockid10 = neighborhood_census_blocks.blockid10
                         AND     cb.target_blockid10 = blocks2.blockid10
             )

--- a/connectivity/access_recreation.sql
+++ b/connectivity/access_recreation.sql
@@ -1,26 +1,26 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
 -- low stress access
-UPDATE  cambridge_census_blocks
+UPDATE  neighborhood_census_blocks
 SET     rec_low_stress = (
             SELECT  COUNT(path_id)
-            FROM    cambridge_paths
+            FROM    neighborhood_paths
             WHERE   EXISTS (
                         SELECT  1
-                        FROM    cambridge_census_block_roads cbr,
-                                cambridge_reachable_roads_low_stress ls,
-                                cambridge_ways,
-                                cambridge_paths
-                        WHERE   cb.source_blockid10 = cambridge_census_blocks.blockid10
+                        FROM    neighborhood_census_block_roads cbr,
+                                neighborhood_reachable_roads_low_stress ls,
+                                neighborhood_ways,
+                                neighborhood_paths
+                        WHERE   cb.source_blockid10 = neighborhood_census_blocks.blockid10
                         AND     cb.target_blockid10 = blocks2.blockid10
                         AND     cb.low_stress
             )
         )
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_zip_codes zips
-            WHERE   ST_Intersects(cambridge_census_blocks.geom,zips.geom)
+            FROM    neighborhood_zip_codes zips
+            WHERE   ST_Intersects(neighborhood_census_blocks.geom,zips.geom)
             AND     zips.zip_code = '02138'
         );

--- a/connectivity/access_schools.sql
+++ b/connectivity/access_schools.sql
@@ -3,6 +3,7 @@
 -- location: neighborhood
 ----------------------------------------
 -- low stress access
+UPDATE neighborhood_census_blocks SET schools_low_stress = NULL;
 UPDATE  neighborhood_census_blocks
 SET     schools_low_stress = (
             SELECT  COUNT(cbs.id)
@@ -17,6 +18,7 @@ WHERE   EXISTS (
         );
 
 -- high stress access
+UPDATE neighborhood_census_blocks SET schools_high_stress = NULL;
 UPDATE  neighborhood_census_blocks
 SET     schools_high_stress = (
             SELECT  COUNT(cbs.id)
@@ -30,6 +32,7 @@ WHERE   EXISTS (
         );
 
 -- low stress population shed for schools in neighborhood
+UPDATE neighborhood_schools SET pop_low_stress = NULL;
 UPDATE  neighborhood_schools
 SET     pop_low_stress = (
             SELECT  SUM(cb.pop10)
@@ -46,6 +49,7 @@ WHERE   EXISTS (
         );
 
 -- high stress population shed for schools in neighborhood
+UPDATE neighborhood_schools SET pop_high_stress = NULL;
 UPDATE  neighborhood_schools
 SET     pop_high_stress = (
             SELECT  SUM(cb.pop10)

--- a/connectivity/access_schools.sql
+++ b/connectivity/access_schools.sql
@@ -1,12 +1,12 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
 -- low stress access
 UPDATE  neighborhood_census_blocks
 SET     schools_low_stress = (
             SELECT  COUNT(cbs.id)
-            FROM    cambridge_connected_census_blocks_schools cbs
+            FROM    neighborhood_connected_census_blocks_schools cbs
             WHERE   cbs.source_blockid10 = neighborhood_census_blocks.blockid10
             AND     cbs.low_stress
         )
@@ -20,7 +20,7 @@ WHERE   EXISTS (
 UPDATE  neighborhood_census_blocks
 SET     schools_high_stress = (
             SELECT  COUNT(cbs.id)
-            FROM    cambridge_connected_census_blocks_schools cbs
+            FROM    neighborhood_connected_census_blocks_schools cbs
             WHERE   cbs.source_blockid10 = neighborhood_census_blocks.blockid10
         )
 WHERE   EXISTS (
@@ -30,32 +30,32 @@ WHERE   EXISTS (
         );
 
 -- low stress population shed for schools in neighborhood
-UPDATE  cambridge_schools
+UPDATE  neighborhood_schools
 SET     pop_low_stress = (
             SELECT  SUM(cb.pop10)
             FROM    neighborhood_census_blocks cb,
-                    cambridge_connected_census_blocks_schools cbs
+                    neighborhood_connected_census_blocks_schools cbs
             WHERE   cb.blockid10 = cbs.source_blockid10
-            AND     cambridge_schools.id = cbs.target_school_id
+            AND     neighborhood_schools.id = cbs.target_school_id
             AND     cbs.low_stress
         )
 WHERE   EXISTS (
             SELECT  1
             FROM    neighborhood_boundary as b
-            WHERE   ST_Intersects(cambridge_schools.geom_pt,b.geom)
+            WHERE   ST_Intersects(neighborhood_schools.geom_pt,b.geom)
         );
 
 -- high stress population shed for schools in neighborhood
-UPDATE  cambridge_schools
+UPDATE  neighborhood_schools
 SET     pop_high_stress = (
             SELECT  SUM(cb.pop10)
             FROM    neighborhood_census_blocks cb,
-                    cambridge_connected_census_blocks_schools cbs
+                    neighborhood_connected_census_blocks_schools cbs
             WHERE   cb.blockid10 = cbs.source_blockid10
-            AND     cambridge_schools.id = cbs.target_school_id
+            AND     neighborhood_schools.id = cbs.target_school_id
         )
 WHERE   EXISTS (
             SELECT  1
             FROM    neighborhood_boundary as b
-            WHERE   ST_Intersects(cambridge_schools.geom_pt,b.geom)
+            WHERE   ST_Intersects(neighborhood_schools.geom_pt,b.geom)
         );

--- a/connectivity/census_block_jobs.sql
+++ b/connectivity/census_block_jobs.sql
@@ -18,12 +18,13 @@ ALTER TABLE "state_od_main_JT00_2014" ALTER COLUMN w_geocode TYPE VARCHAR(15);
 UPDATE "state_od_main_JT00_2014" SET w_geocode = rpad(w_geocode,15,'0'); --just in case we lost any trailing zeros
 
 -- indexes
-CREATE INDEX tidx_auxjtw ON "state_od_aux_JT00_2014" (w_geocode);
-CREATE INDEX tidx_mainjtw ON "state_od_main_JT00_2014" (w_geocode);
+CREATE INDEX IF NOT EXISTS tidx_auxjtw ON "state_od_aux_JT00_2014" (w_geocode);
+CREATE INDEX IF NOT EXISTS tidx_mainjtw ON "state_od_main_JT00_2014" (w_geocode);
 ANALYZE "state_od_aux_JT00_2014" (w_geocode);
 ANALYZE "state_od_main_JT00_2014" (w_geocode);
 
 -- create combined table
+DROP TABLE IF EXISTS generated.neighborhood_census_block_jobs;
 CREATE TABLE generated.neighborhood_census_block_jobs (
     id SERIAL PRIMARY KEY,
     blockid10 VARCHAR(15),
@@ -53,9 +54,5 @@ SET     jobs =  jobs +
         ),0);
 
 -- indexes
-CREATE INDEX idx_neighborhood_blkjobs ON neighborhood_census_block_jobs (blockid10);
+CREATE INDEX IF NOT EXISTS idx_neighborhood_blkjobs ON neighborhood_census_block_jobs (blockid10);
 ANALYZE neighborhood_census_block_jobs (blockid10);
-
--- drop import tables
--- DROP TABLE IF EXISTS "state_od_aux_JT00_2014";
--- DROP TABLE IF EXISTS "state_od_main_JT00_2014";

--- a/connectivity/census_block_jobs.sql
+++ b/connectivity/census_block_jobs.sql
@@ -1,6 +1,6 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 -- data downloaded from http://lehd.ces.census.gov/data/
 -- or http://lehd.ces.census.gov/data/lodes/LODES7/
 --     "ma_od_main_JT00_2014".csv
@@ -24,37 +24,37 @@ ANALYZE "state_od_aux_JT00_2014" (w_geocode);
 ANALYZE "state_od_main_JT00_2014" (w_geocode);
 
 -- create combined table
-CREATE TABLE generated.cambridge_census_block_jobs (
+CREATE TABLE generated.neighborhood_census_block_jobs (
     id SERIAL PRIMARY KEY,
     blockid10 VARCHAR(15),
     jobs INT
 );
 
 -- add blocks of interest
-INSERT INTO generated.cambridge_census_block_jobs (blockid10)
+INSERT INTO generated.neighborhood_census_block_jobs (blockid10)
 SELECT  blocks.blockid10
 FROM    neighborhood_census_blocks blocks;
 
 -- add main data
-UPDATE  generated.cambridge_census_block_jobs
+UPDATE  generated.neighborhood_census_block_jobs
 SET     jobs = COALESCE((
             SELECT  SUM(j."S000")
             FROM    "state_od_main_JT00_2014" j
-            WHERE   j.w_geocode = cambridge_census_block_jobs.blockid10
+            WHERE   j.w_geocode = neighborhood_census_block_jobs.blockid10
         ),0);
 
 -- add aux data
-UPDATE  generated.cambridge_census_block_jobs
+UPDATE  generated.neighborhood_census_block_jobs
 SET     jobs =  jobs +
                 COALESCE((
                     SELECT  SUM(j."S000")
                     FROM    "state_od_aux_JT00_2014" j
-                    WHERE   j.w_geocode = cambridge_census_block_jobs.blockid10
+                    WHERE   j.w_geocode = neighborhood_census_block_jobs.blockid10
         ),0);
 
 -- indexes
-CREATE INDEX idx_cambridge_blkjobs ON cambridge_census_block_jobs (blockid10);
-ANALYZE cambridge_census_block_jobs (blockid10);
+CREATE INDEX idx_neighborhood_blkjobs ON neighborhood_census_block_jobs (blockid10);
+ANALYZE neighborhood_census_block_jobs (blockid10);
 
 -- drop import tables
 -- DROP TABLE IF EXISTS "state_od_aux_JT00_2014";

--- a/connectivity/census_block_roads.sql
+++ b/connectivity/census_block_roads.sql
@@ -20,6 +20,6 @@ FROM    neighborhood_census_blocks blocks,
         neighborhood_ways ways
 WHERE   ST_DWithin(blocks.geom,ways.geom,50);
 
-CREATE INDEX idx_neighborhood_censblkrds
+CREATE INDEX IF NOT EXISTS idx_neighborhood_censblkrds
 ON generated.neighborhood_census_block_roads (blockid10,road_id);
 ANALYZE generated.neighborhood_census_block_roads;

--- a/connectivity/census_block_roads.sql
+++ b/connectivity/census_block_roads.sql
@@ -1,25 +1,25 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-DROP TABLE IF EXISTS generated.cambridge_census_block_roads;
+DROP TABLE IF EXISTS generated.neighborhood_census_block_roads;
 
-CREATE TABLE generated.cambridge_census_block_roads (
+CREATE TABLE generated.neighborhood_census_block_roads (
     id SERIAL PRIMARY KEY,
     blockid10 VARCHAR(15),
     road_id INT
 );
 
-INSERT INTO generated.cambridge_census_block_roads (
+INSERT INTO generated.neighborhood_census_block_roads (
     blockid10,
     road_id
 )
 SELECT  blocks.blockid10,
         ways.road_id
 FROM    neighborhood_census_blocks blocks,
-        cambridge_ways ways
+        neighborhood_ways ways
 WHERE   ST_DWithin(blocks.geom,ways.geom,50);
 
-CREATE INDEX idx_cambridge_censblkrds
-ON generated.cambridge_census_block_roads (blockid10,road_id);
-ANALYZE generated.cambridge_census_block_roads;
+CREATE INDEX idx_neighborhood_censblkrds
+ON generated.neighborhood_census_block_roads (blockid10,road_id);
+ANALYZE generated.neighborhood_census_block_roads;

--- a/connectivity/census_blocks.sql
+++ b/connectivity/census_blocks.sql
@@ -6,14 +6,14 @@
 -- blkpophu file
 ----------------------------------------
 
-ALTER TABLE neighborhood_census_blocks ADD COLUMN pop_low_stress INT;
-ALTER TABLE neighborhood_census_blocks ADD COLUMN pop_high_stress INT;
-ALTER TABLE neighborhood_census_blocks ADD COLUMN emp_low_stress INT;
-ALTER TABLE neighborhood_census_blocks ADD COLUMN emp_high_stress INT;
-ALTER TABLE neighborhood_census_blocks ADD COLUMN schools_low_stress INT;
-ALTER TABLE neighborhood_census_blocks ADD COLUMN schools_high_stress INT;
-ALTER TABLE neighborhood_census_blocks ADD COLUMN rec_low_stress INT;
-ALTER TABLE neighborhood_census_blocks ADD COLUMN rec_high_stress INT;
+ALTER TABLE neighborhood_census_blocks ADD COLUMN IF NOT EXISTS pop_low_stress INT;
+ALTER TABLE neighborhood_census_blocks ADD COLUMN IF NOT EXISTS pop_high_stress INT;
+ALTER TABLE neighborhood_census_blocks ADD COLUMN IF NOT EXISTS emp_low_stress INT;
+ALTER TABLE neighborhood_census_blocks ADD COLUMN IF NOT EXISTS emp_high_stress INT;
+ALTER TABLE neighborhood_census_blocks ADD COLUMN IF NOT EXISTS schools_low_stress INT;
+ALTER TABLE neighborhood_census_blocks ADD COLUMN IF NOT EXISTS schools_high_stress INT;
+ALTER TABLE neighborhood_census_blocks ADD COLUMN IF NOT EXISTS rec_low_stress INT;
+ALTER TABLE neighborhood_census_blocks ADD COLUMN IF NOT EXISTS rec_high_stress INT;
 
-CREATE INDEX idx_neighborhood_blocks10 ON neighborhood_census_blocks (blockid10);
+CREATE INDEX IF NOT EXISTS idx_neighborhood_blocks10 ON neighborhood_census_blocks (blockid10);
 ANALYZE neighborhood_census_blocks (blockid10);

--- a/connectivity/census_blocks.sql
+++ b/connectivity/census_blocks.sql
@@ -16,4 +16,5 @@ ALTER TABLE neighborhood_census_blocks ADD COLUMN IF NOT EXISTS rec_low_stress I
 ALTER TABLE neighborhood_census_blocks ADD COLUMN IF NOT EXISTS rec_high_stress INT;
 
 CREATE INDEX IF NOT EXISTS idx_neighborhood_blocks10 ON neighborhood_census_blocks (blockid10);
-ANALYZE neighborhood_census_blocks (blockid10);
+CREATE INDEX IF NOT EXISTS idx_neighborhood_geom ON neighborhood_census_blocks USING GIST (geom);
+ANALYZE neighborhood_census_blocks;

--- a/connectivity/connected_census_blocks.sql
+++ b/connectivity/connected_census_blocks.sql
@@ -14,36 +14,31 @@ CREATE TABLE generated.neighborhood_connected_census_blocks (
     high_stress_cost INT
 );
 
-INSERT INTO generated.neighborhood_connected_census_blocks (  -- took 2 hrs on the server
+INSERT INTO generated.neighborhood_connected_census_blocks (
     source_blockid10, target_blockid10, low_stress, high_stress
 )
 SELECT  source_block.blockid10,
         target_block.blockid10,
         'f'::BOOLEAN,
         't'::BOOLEAN
-FROM    neighborhood_census_blocks source_block,
-        neighborhood_census_blocks target_block
-WHERE   EXISTS (
-            SELECT  1
-            FROM    neighborhood_boundary AS b
-            WHERE   ST_Intersects(source_block.geom,b.geom)
-        )
-AND     source_block.geom <#> target_block.geom < 11000
-AND     EXISTS (
-            SELECT  1
-            FROM    neighborhood_census_block_roads source_br,
-                    neighborhood_census_block_roads target_br,
-                    neighborhood_reachable_roads_high_stress hs
-            WHERE   source_block.blockid10 = source_br.blockid10
-            AND     target_block.blockid10 = target_br.blockid10
-            AND     hs.base_road = source_br.road_id
-            AND     hs.target_road = target_br.road_id
-        );
+FROM    neighborhood_boundary b
+JOIN    neighborhood_census_blocks source_block
+        ON  ST_Intersects(source_block.geom,b.geom)
+JOIN    neighborhood_census_blocks target_block
+        ON  source_block.geom <#> target_block.geom < 11000
+JOIN    neighborhood_census_block_roads source_br
+        ON  source_block.blockid10 = source_br.blockid10
+JOIN    neighborhood_census_block_roads target_br
+        ON  target_block.blockid10 = target_br.blockid10
+JOIN    neighborhood_reachable_roads_high_stress hs
+        ON  hs.base_road = source_br.road_id
+        AND hs.target_road = target_br.road_id
+GROUP BY source_block.blockid10, target_block.blockid10
+;
 
 -- block pair index
-CREATE INDEX idx_neighborhood_blockpairs
-ON neighborhood_connected_census_blocks (source_blockid10,target_blockid10);
-ANALYZE neighborhood_connected_census_blocks (source_blockid10,target_blockid10);
+CREATE UNIQUE INDEX idx_neighborhood_blockpairs ON neighborhood_connected_census_blocks (source_blockid10,target_blockid10);
+ANALYZE neighborhood_connected_census_blocks;
 
 -- low stress
 UPDATE  neighborhood_connected_census_blocks
@@ -82,4 +77,4 @@ AND     (
 -- stress index
 CREATE INDEX IF NOT EXISTS idx_neighborhood_blockpairs_lstress ON neighborhood_connected_census_blocks (low_stress);
 CREATE INDEX IF NOT EXISTS idx_neighborhood_blockpairs_hstress ON neighborhood_connected_census_blocks (high_stress);
-ANALYZE neighborhood_connected_census_blocks (low_stress,high_stress);
+ANALYZE neighborhood_connected_census_blocks;

--- a/connectivity/connected_census_blocks.sql
+++ b/connectivity/connected_census_blocks.sql
@@ -1,10 +1,10 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-DROP TABLE IF EXISTS generated.cambridge_connected_census_blocks;
+DROP TABLE IF EXISTS generated.neighborhood_connected_census_blocks;
 
-CREATE TABLE generated.cambridge_connected_census_blocks (
+CREATE TABLE generated.neighborhood_connected_census_blocks (
     id SERIAL PRIMARY KEY,
     source_blockid10 VARCHAR(15),
     target_blockid10 VARCHAR(15),
@@ -14,7 +14,7 @@ CREATE TABLE generated.cambridge_connected_census_blocks (
     high_stress_cost INT
 );
 
-INSERT INTO generated.cambridge_connected_census_blocks (  -- took 2 hrs on the server
+INSERT INTO generated.neighborhood_connected_census_blocks (  -- took 2 hrs on the server
     source_blockid10, target_blockid10, low_stress, high_stress
 )
 SELECT  source_block.blockid10,
@@ -31,9 +31,9 @@ WHERE   EXISTS (
 AND     source_block.geom <#> target_block.geom < 11000
 AND     EXISTS (
             SELECT  1
-            FROM    cambridge_census_block_roads source_br,
-                    cambridge_census_block_roads target_br,
-                    cambridge_reachable_roads_high_stress hs
+            FROM    neighborhood_census_block_roads source_br,
+                    neighborhood_census_block_roads target_br,
+                    neighborhood_reachable_roads_high_stress hs
             WHERE   source_block.blockid10 = source_br.blockid10
             AND     target_block.blockid10 = target_br.blockid10
             AND     hs.base_road = source_br.road_id
@@ -41,18 +41,18 @@ AND     EXISTS (
         );
 
 -- block pair index
-CREATE INDEX idx_cambridge_blockpairs
-ON cambridge_connected_census_blocks (source_blockid10,target_blockid10);
-ANALYZE cambridge_connected_census_blocks (source_blockid10,target_blockid10);
+CREATE INDEX idx_neighborhood_blockpairs
+ON neighborhood_connected_census_blocks (source_blockid10,target_blockid10);
+ANALYZE neighborhood_connected_census_blocks (source_blockid10,target_blockid10);
 
 -- low stress
-UPDATE  cambridge_connected_census_blocks
+UPDATE  neighborhood_connected_census_blocks
 SET     low_stress = 't'::BOOLEAN
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_census_block_roads source_br,
-                    cambridge_census_block_roads target_br,
-                    cambridge_reachable_roads_low_stress ls
+            FROM    neighborhood_census_block_roads source_br,
+                    neighborhood_census_block_roads target_br,
+                    neighborhood_reachable_roads_low_stress ls
             WHERE   source_blockid10 = source_br.blockid10
             AND     target_blockid10 = target_br.blockid10
             AND     ls.base_road = source_br.road_id
@@ -60,9 +60,9 @@ WHERE   EXISTS (
         )
 AND     (
             SELECT  MIN(total_cost)
-            FROM    cambridge_census_block_roads source_br,
-                    cambridge_census_block_roads target_br,
-                    cambridge_reachable_roads_low_stress ls
+            FROM    neighborhood_census_block_roads source_br,
+                    neighborhood_census_block_roads target_br,
+                    neighborhood_reachable_roads_low_stress ls
             WHERE   source_blockid10 = source_br.blockid10
             AND     target_blockid10 = target_br.blockid10
             AND     ls.base_road = source_br.road_id
@@ -70,9 +70,9 @@ AND     (
         )::FLOAT /
         COALESCE((
             SELECT  MIN(total_cost) + 1
-            FROM    cambridge_census_block_roads source_br,
-                    cambridge_census_block_roads target_br,
-                    cambridge_reachable_roads_high_stress hs
+            FROM    neighborhood_census_block_roads source_br,
+                    neighborhood_census_block_roads target_br,
+                    neighborhood_reachable_roads_high_stress hs
             WHERE   source_blockid10 = source_br.blockid10
             AND     target_blockid10 = target_br.blockid10
             AND     hs.base_road = source_br.road_id
@@ -80,6 +80,6 @@ AND     (
         ),11000) <= 1.3;
 
 -- stress index
-CREATE INDEX idx_cambridge_blockpairs_lstress ON cambridge_connected_census_blocks (low_stress);
-CREATE INDEX idx_cambridge_blockpairs_hstress ON cambridge_connected_census_blocks (high_stress);
-ANALYZE cambridge_connected_census_blocks (low_stress,high_stress);
+CREATE INDEX idx_neighborhood_blockpairs_lstress ON neighborhood_connected_census_blocks (low_stress);
+CREATE INDEX idx_neighborhood_blockpairs_hstress ON neighborhood_connected_census_blocks (high_stress);
+ANALYZE neighborhood_connected_census_blocks (low_stress,high_stress);

--- a/connectivity/connected_census_blocks.sql
+++ b/connectivity/connected_census_blocks.sql
@@ -80,6 +80,6 @@ AND     (
         ),11000) <= 1.3;
 
 -- stress index
-CREATE INDEX idx_neighborhood_blockpairs_lstress ON neighborhood_connected_census_blocks (low_stress);
-CREATE INDEX idx_neighborhood_blockpairs_hstress ON neighborhood_connected_census_blocks (high_stress);
+CREATE INDEX IF NOT EXISTS idx_neighborhood_blockpairs_lstress ON neighborhood_connected_census_blocks (low_stress);
+CREATE INDEX IF NOT EXISTS idx_neighborhood_blockpairs_hstress ON neighborhood_connected_census_blocks (high_stress);
 ANALYZE neighborhood_connected_census_blocks (low_stress,high_stress);

--- a/connectivity/connected_census_blocks_schools.sql
+++ b/connectivity/connected_census_blocks_schools.sql
@@ -41,7 +41,7 @@ AND     EXISTS (
         );
 
 -- block pair index
-CREATE INDEX idx_neighborhood_blockschoolpairs
+CREATE INDEX IF NOT EXISTS idx_neighborhood_blockschoolpairs
 ON neighborhood_connected_census_blocks_schools (source_blockid10,target_school_id);
 ANALYZE neighborhood_connected_census_blocks_schools (source_blockid10,target_school_id);
 
@@ -80,6 +80,6 @@ AND     (
         ),11000) <= 1.3;
 
 -- stress index
-CREATE INDEX idx_neighborhood_blockschl_lstress ON neighborhood_connected_census_blocks_schools (low_stress);
-CREATE INDEX idx_neighborhood_blockschl_hstress ON neighborhood_connected_census_blocks_schools (high_stress);
+CREATE INDEX IF NOT EXISTS idx_neighborhood_blockschl_lstress ON neighborhood_connected_census_blocks_schools (low_stress);
+CREATE INDEX IF NOT EXISTS idx_neighborhood_blockschl_hstress ON neighborhood_connected_census_blocks_schools (high_stress);
 ANALYZE neighborhood_connected_census_blocks_schools (low_stress,high_stress);

--- a/connectivity/connected_census_blocks_schools.sql
+++ b/connectivity/connected_census_blocks_schools.sql
@@ -1,10 +1,10 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-DROP TABLE IF EXISTS generated.cambridge_connected_census_blocks_schools;
+DROP TABLE IF EXISTS generated.neighborhood_connected_census_blocks_schools;
 
-CREATE TABLE generated.cambridge_connected_census_blocks_schools (
+CREATE TABLE generated.neighborhood_connected_census_blocks_schools (
     id SERIAL PRIMARY KEY,
     source_blockid10 VARCHAR(15),
     target_school_id INT,
@@ -14,7 +14,7 @@ CREATE TABLE generated.cambridge_connected_census_blocks_schools (
     high_stress_cost INT
 );
 
-INSERT INTO generated.cambridge_connected_census_blocks_schools (
+INSERT INTO generated.neighborhood_connected_census_blocks_schools (
     source_blockid10, target_school_id, low_stress, high_stress
 )
 SELECT  blocks.blockid10,
@@ -22,7 +22,7 @@ SELECT  blocks.blockid10,
         'f'::BOOLEAN,
         't'::BOOLEAN
 FROM    neighborhood_census_blocks blocks,
-        cambridge_schools schools
+        neighborhood_schools schools
 WHERE   EXISTS (
             SELECT  1
             FROM    neighborhood_boundary AS b
@@ -31,9 +31,9 @@ WHERE   EXISTS (
 AND     blocks.geom <#> schools.geom_pt < 11000
 AND     EXISTS (
             SELECT  1
-            FROM    cambridge_census_block_roads source_br,
-                    cambridge_school_roads target_sr,
-                    cambridge_reachable_roads_high_stress hs
+            FROM    neighborhood_census_block_roads source_br,
+                    neighborhood_school_roads target_sr,
+                    neighborhood_reachable_roads_high_stress hs
             WHERE   blocks.blockid10 = source_br.blockid10
             AND     schools.id = target_sr.school_id
             AND     hs.base_road = source_br.road_id
@@ -41,18 +41,18 @@ AND     EXISTS (
         );
 
 -- block pair index
-CREATE INDEX idx_cambridge_blockschoolpairs
-ON cambridge_connected_census_blocks_schools (source_blockid10,target_school_id);
-ANALYZE cambridge_connected_census_blocks_schools (source_blockid10,target_school_id);
+CREATE INDEX idx_neighborhood_blockschoolpairs
+ON neighborhood_connected_census_blocks_schools (source_blockid10,target_school_id);
+ANALYZE neighborhood_connected_census_blocks_schools (source_blockid10,target_school_id);
 
 -- low stress
-UPDATE  cambridge_connected_census_blocks_schools
+UPDATE  neighborhood_connected_census_blocks_schools
 SET     low_stress = 't'::BOOLEAN
 WHERE   EXISTS (
             SELECT  1
-            FROM    cambridge_census_block_roads source_br,
-                    cambridge_school_roads target_sr,
-                    cambridge_reachable_roads_low_stress ls
+            FROM    neighborhood_census_block_roads source_br,
+                    neighborhood_school_roads target_sr,
+                    neighborhood_reachable_roads_low_stress ls
             WHERE   source_blockid10 = source_br.blockid10
             AND     target_school_id = target_sr.school_id
             AND     ls.base_road = source_br.road_id
@@ -60,9 +60,9 @@ WHERE   EXISTS (
         )
 AND     (
             SELECT  MIN(total_cost)
-            FROM    cambridge_census_block_roads source_br,
-                    cambridge_school_roads target_sr,
-                    cambridge_reachable_roads_low_stress ls
+            FROM    neighborhood_census_block_roads source_br,
+                    neighborhood_school_roads target_sr,
+                    neighborhood_reachable_roads_low_stress ls
             WHERE   source_blockid10 = source_br.blockid10
             AND     target_school_id = target_sr.school_id
             AND     ls.base_road = source_br.road_id
@@ -70,9 +70,9 @@ AND     (
         )::FLOAT /
         COALESCE((
             SELECT  MIN(total_cost) + 1
-            FROM    cambridge_census_block_roads source_br,
-                    cambridge_school_roads target_sr,
-                    cambridge_reachable_roads_high_stress hs
+            FROM    neighborhood_census_block_roads source_br,
+                    neighborhood_school_roads target_sr,
+                    neighborhood_reachable_roads_high_stress hs
             WHERE   source_blockid10 = source_br.blockid10
             AND     target_school_id = target_sr.school_id
             AND     hs.base_road = source_br.road_id
@@ -80,6 +80,6 @@ AND     (
         ),11000) <= 1.3;
 
 -- stress index
-CREATE INDEX idx_cambridge_blockschl_lstress ON cambridge_connected_census_blocks_schools (low_stress);
-CREATE INDEX idx_cambridge_blockschl_hstress ON cambridge_connected_census_blocks_schools (high_stress);
-ANALYZE cambridge_connected_census_blocks_schools (low_stress,high_stress);
+CREATE INDEX idx_neighborhood_blockschl_lstress ON neighborhood_connected_census_blocks_schools (low_stress);
+CREATE INDEX idx_neighborhood_blockschl_hstress ON neighborhood_connected_census_blocks_schools (high_stress);
+ANALYZE neighborhood_connected_census_blocks_schools (low_stress,high_stress);

--- a/connectivity/coverage.sql
+++ b/connectivity/coverage.sql
@@ -1,21 +1,21 @@
 SELECT      r.road_id,
             r.geom,
             COUNT(sheds.node) AS ct
-FROM        cambridge_ways_net_vert v,
-            cambridge_ways r,
-            cambridge_boundary,
+FROM        neighborhood_ways_net_vert v,
+            neighborhood_ways r,
+            neighborhood_boundary,
             pgr_drivingDistance('
                 SELECT  link_id AS id,
                         source_vert AS source,
                         target_vert AS target,
                         link_cost AS cost
-                FROM    cambridge_ways_net_link
+                FROM    neighborhood_ways_net_link
                 WHERE   link_stress = 1',
                 v.vert_id,
                 10560,
                 directed := true
             ) sheds
-WHERE       ST_Intersects(r.geom,cambridge_boundary.geom)
+WHERE       ST_Intersects(r.geom,neighborhood_boundary.geom)
 AND         v.road_id = r.road_id
 --and v.road_id = 1467
 GROUP BY    r.road_id,

--- a/connectivity/overall_scores.sql
+++ b/connectivity/overall_scores.sql
@@ -1,10 +1,10 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-DROP TABLE IF EXISTS generated.cambridge_overall_scores;
+DROP TABLE IF EXISTS generated.neighborhood_overall_scores;
 
-CREATE TABLE generated.cambridge_overall_scores (
+CREATE TABLE generated.neighborhood_overall_scores (
     id SERIAL PRIMARY KEY,
     category TEXT,
     score_name TEXT,
@@ -13,7 +13,7 @@ CREATE TABLE generated.cambridge_overall_scores (
 );
 
 -- median pop access low stress
-INSERT INTO generated.cambridge_overall_scores (
+INSERT INTO generated.neighborhood_overall_scores (
     category, score_name, score, notes
 )
 SELECT  'Population',
@@ -30,7 +30,7 @@ WHERE   EXISTS (
         );
 
 -- median pop access high stress
-INSERT INTO generated.cambridge_overall_scores (
+INSERT INTO generated.neighborhood_overall_scores (
     category, score_name, score, notes
 )
 SELECT  'Population',
@@ -47,7 +47,7 @@ WHERE   EXISTS (
         );
 
 -- median pop access ratio
-INSERT INTO generated.cambridge_overall_scores (
+INSERT INTO generated.neighborhood_overall_scores (
     category, score_name, score, notes
 )
 SELECT  'Population',
@@ -65,7 +65,7 @@ WHERE   EXISTS (
         );
 
 -- 70th percentile pop access ratio
-INSERT INTO generated.cambridge_overall_scores (
+INSERT INTO generated.neighborhood_overall_scores (
     category, score_name, score, notes
 )
 SELECT  'Population',
@@ -83,7 +83,7 @@ WHERE   EXISTS (
         );
 
 -- avg pop access ratio
-INSERT INTO generated.cambridge_overall_scores (
+INSERT INTO generated.neighborhood_overall_scores (
     category, score_name, score, notes
 )
 SELECT  'Population',
@@ -101,7 +101,7 @@ WHERE   EXISTS (
         );
 
 -- median jobs access low stress
-INSERT INTO generated.cambridge_overall_scores (
+INSERT INTO generated.neighborhood_overall_scores (
     category, score_name, score, notes
 )
 SELECT  'Employment',
@@ -118,7 +118,7 @@ WHERE   EXISTS (
         );
 
 -- median jobs access high stress
-INSERT INTO generated.cambridge_overall_scores (
+INSERT INTO generated.neighborhood_overall_scores (
     category, score_name, score, notes
 )
 SELECT  'Employment',
@@ -135,7 +135,7 @@ WHERE   EXISTS (
         );
 
 -- median jobs access ratio
-INSERT INTO generated.cambridge_overall_scores (
+INSERT INTO generated.neighborhood_overall_scores (
     category, score_name, score, notes
 )
 SELECT  'Employment',
@@ -153,7 +153,7 @@ WHERE   EXISTS (
         );
 
 -- 70th percentile jobs access ratio
-INSERT INTO generated.cambridge_overall_scores (
+INSERT INTO generated.neighborhood_overall_scores (
     category, score_name, score, notes
 )
 SELECT  'Employment',
@@ -171,7 +171,7 @@ WHERE   EXISTS (
         );
 
 -- avg jobs access ratio
-INSERT INTO generated.cambridge_overall_scores (
+INSERT INTO generated.neighborhood_overall_scores (
     category, score_name, score, notes
 )
 SELECT  'Employment',
@@ -189,7 +189,7 @@ WHERE   EXISTS (
         );
 
 -- median schools access low stress
-INSERT INTO generated.cambridge_overall_scores (
+INSERT INTO generated.neighborhood_overall_scores (
     category, score_name, score, notes
 )
 SELECT  'Schools',
@@ -206,7 +206,7 @@ WHERE   EXISTS (
         );
 
 -- median schools access high stress
-INSERT INTO generated.cambridge_overall_scores (
+INSERT INTO generated.neighborhood_overall_scores (
     category, score_name, score, notes
 )
 SELECT  'Schools',
@@ -223,7 +223,7 @@ WHERE   EXISTS (
         );
 
 -- school low stress pop shed access
-INSERT INTO generated.cambridge_overall_scores (
+INSERT INTO generated.neighborhood_overall_scores (
     category, score_name, score, notes
 )
 SELECT  'Schools',
@@ -232,15 +232,15 @@ SELECT  'Schools',
         regexp_replace('Population with low stress access to schools
             in the neighborhood expressed as an average of all
             schools in the neighborhood','\n\s+',' ')
-FROM    cambridge_schools
+FROM    neighborhood_schools
 WHERE   EXISTS (
             SELECT  1
             FROM    neighborhood_boundary AS b
-            WHERE   ST_Intersects(cambridge_schools.geom_pt,b.geom)
+            WHERE   ST_Intersects(neighborhood_schools.geom_pt,b.geom)
         );
 
 -- school high stress pop shed access
-INSERT INTO generated.cambridge_overall_scores (
+INSERT INTO generated.neighborhood_overall_scores (
     category, score_name, score, notes
 )
 SELECT  'Schools',
@@ -249,15 +249,15 @@ SELECT  'Schools',
         regexp_replace('Population with high stress access to schools
             in the neighborhood expressed as an average of all
             schools in the neighborhood','\n\s+',' ')
-FROM    cambridge_schools
+FROM    neighborhood_schools
 WHERE   EXISTS (
             SELECT  1
             FROM    neighborhood_boundary AS b
-            WHERE   ST_Intersects(cambridge_schools.geom_pt,b.geom)
+            WHERE   ST_Intersects(neighborhood_schools.geom_pt,b.geom)
         );
 
 -- school pop shed access ratio
-INSERT INTO generated.cambridge_overall_scores (
+INSERT INTO generated.neighborhood_overall_scores (
     category, score_name, score, notes
 )
 SELECT  'Schools',
@@ -267,9 +267,9 @@ SELECT  'Schools',
             access to schools to population with high stress access
             in the neighborhood expressed as an average of all
             schools in the neighborhood','\n\s+',' ')
-FROM    cambridge_schools
+FROM    neighborhood_schools
 WHERE   EXISTS (
             SELECT  1
             FROM    neighborhood_boundary AS b
-            WHERE   ST_Intersects(cambridge_schools.geom_pt,b.geom)
+            WHERE   ST_Intersects(neighborhood_schools.geom_pt,b.geom)
         );

--- a/connectivity/reachable_roads_high_stress.sql
+++ b/connectivity/reachable_roads_high_stress.sql
@@ -41,6 +41,6 @@ WHERE   EXISTS (
 AND     r1.road_id = v1.road_id
 AND     v2.vert_id = sheds.node;
 
-CREATE INDEX idx_neighborhood_rchblrdshistrss_b ON generated.neighborhood_reachable_roads_high_stress (base_road);
-CREATE INDEX idx_neighborhood_rchblrdshistrss_t ON generated.neighborhood_reachable_roads_high_stress (target_road);
+CREATE INDEX IF NOT EXISTS idx_neighborhood_rchblrdshistrss_b ON generated.neighborhood_reachable_roads_high_stress (base_road);
+CREATE INDEX IF NOT EXISTS idx_neighborhood_rchblrdshistrss_t ON generated.neighborhood_reachable_roads_high_stress (target_road);
 ANALYZE generated.neighborhood_reachable_roads_high_stress (base_road,target_road);

--- a/connectivity/reachable_roads_high_stress.sql
+++ b/connectivity/reachable_roads_high_stress.sql
@@ -41,6 +41,6 @@ WHERE   EXISTS (
 AND     r1.road_id = v1.road_id
 AND     v2.vert_id = sheds.node;
 
-CREATE INDEX IF NOT EXISTS idx_neighborhood_rchblrdshistrss_b ON generated.neighborhood_reachable_roads_high_stress (base_road);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_neighborhood_rchblrdshistrss_b ON generated.neighborhood_reachable_roads_high_stress (base_road, target_road);
 CREATE INDEX IF NOT EXISTS idx_neighborhood_rchblrdshistrss_t ON generated.neighborhood_reachable_roads_high_stress (target_road);
-ANALYZE generated.neighborhood_reachable_roads_high_stress (base_road,target_road);
+ANALYZE generated.neighborhood_reachable_roads_high_stress;

--- a/connectivity/reachable_roads_high_stress.sql
+++ b/connectivity/reachable_roads_high_stress.sql
@@ -1,18 +1,18 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 -- maximum network distsance: 10560 ft
 ----------------------------------------
-DROP TABLE IF EXISTS generated.cambridge_reachable_roads_high_stress;
+DROP TABLE IF EXISTS generated.neighborhood_reachable_roads_high_stress;
 
-CREATE TABLE generated.cambridge_reachable_roads_high_stress (
+CREATE TABLE generated.neighborhood_reachable_roads_high_stress (
     id SERIAL PRIMARY KEY,
     base_road INT,
     target_road INT,
     total_cost FLOAT
 );
 
-INSERT INTO generated.cambridge_reachable_roads_high_stress (
+INSERT INTO generated.neighborhood_reachable_roads_high_stress (
     base_road,
     target_road,
     total_cost
@@ -20,15 +20,15 @@ INSERT INTO generated.cambridge_reachable_roads_high_stress (
 SELECT  r1.road_id,
         v2.road_id,
         sheds.agg_cost
-FROM    cambridge_ways r1,
-        cambridge_ways_net_vert v1,
-        cambridge_ways_net_vert v2,
+FROM    neighborhood_ways r1,
+        neighborhood_ways_net_vert v1,
+        neighborhood_ways_net_vert v2,
         pgr_drivingDistance('
             SELECT  link_id AS id,
                     source_vert AS source,
                     target_vert AS target,
                     link_cost AS cost
-            FROM    cambridge_ways_net_link',
+            FROM    neighborhood_ways_net_link',
             v1.vert_id,
             10560,
             directed := true
@@ -41,6 +41,6 @@ WHERE   EXISTS (
 AND     r1.road_id = v1.road_id
 AND     v2.vert_id = sheds.node;
 
-CREATE INDEX idx_cambridge_rchblrdshistrss_b ON generated.cambridge_reachable_roads_high_stress (base_road);
-CREATE INDEX idx_cambridge_rchblrdshistrss_t ON generated.cambridge_reachable_roads_high_stress (target_road);
-ANALYZE generated.cambridge_reachable_roads_high_stress (base_road,target_road);
+CREATE INDEX idx_neighborhood_rchblrdshistrss_b ON generated.neighborhood_reachable_roads_high_stress (base_road);
+CREATE INDEX idx_neighborhood_rchblrdshistrss_t ON generated.neighborhood_reachable_roads_high_stress (target_road);
+ANALYZE generated.neighborhood_reachable_roads_high_stress (base_road,target_road);

--- a/connectivity/reachable_roads_low_stress.sql
+++ b/connectivity/reachable_roads_low_stress.sql
@@ -42,6 +42,6 @@ WHERE   EXISTS (
 AND     r1.road_id = v1.road_id
 AND     v2.vert_id = sheds.node;
 
-CREATE INDEX idx_neighborhood_rchblrdslowstrss_b ON generated.neighborhood_reachable_roads_low_stress (base_road);
-CREATE INDEX idx_neighborhood_rchblrdslowstrss_t ON generated.neighborhood_reachable_roads_low_stress (target_road);
+CREATE INDEX IF NOT EXISTS idx_neighborhood_rchblrdslowstrss_b ON generated.neighborhood_reachable_roads_low_stress (base_road);
+CREATE INDEX IF NOT EXISTS idx_neighborhood_rchblrdslowstrss_t ON generated.neighborhood_reachable_roads_low_stress (target_road);
 ANALYZE generated.neighborhood_reachable_roads_low_stress (base_road,target_road);

--- a/connectivity/reachable_roads_low_stress.sql
+++ b/connectivity/reachable_roads_low_stress.sql
@@ -1,18 +1,18 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 -- maximum network distsance: 10560 ft
 ----------------------------------------
-DROP TABLE IF EXISTS generated.cambridge_reachable_roads_low_stress;
+DROP TABLE IF EXISTS generated.neighborhood_reachable_roads_low_stress;
 
-CREATE TABLE generated.cambridge_reachable_roads_low_stress (
+CREATE TABLE generated.neighborhood_reachable_roads_low_stress (
     id SERIAL PRIMARY KEY,
     base_road INT,
     target_road INT,
     total_cost FLOAT
 );
 
-INSERT INTO generated.cambridge_reachable_roads_low_stress (
+INSERT INTO generated.neighborhood_reachable_roads_low_stress (
     base_road,
     target_road,
     total_cost
@@ -20,15 +20,15 @@ INSERT INTO generated.cambridge_reachable_roads_low_stress (
 SELECT  r1.road_id,
         v2.road_id,
         sheds.agg_cost
-FROM    cambridge_ways r1,
-        cambridge_ways_net_vert v1,
-        cambridge_ways_net_vert v2,
+FROM    neighborhood_ways r1,
+        neighborhood_ways_net_vert v1,
+        neighborhood_ways_net_vert v2,
         pgr_drivingDistance('
             SELECT  link_id AS id,
                     source_vert AS source,
                     target_vert AS target,
                     link_cost AS cost
-            FROM    cambridge_ways_net_link
+            FROM    neighborhood_ways_net_link
             WHERE   link_stress = 1',
             v1.vert_id,
             10560,
@@ -42,6 +42,6 @@ WHERE   EXISTS (
 AND     r1.road_id = v1.road_id
 AND     v2.vert_id = sheds.node;
 
-CREATE INDEX idx_cambridge_rchblrdslowstrss_b ON generated.cambridge_reachable_roads_low_stress (base_road);
-CREATE INDEX idx_cambridge_rchblrdslowstrss_t ON generated.cambridge_reachable_roads_low_stress (target_road);
-ANALYZE generated.cambridge_reachable_roads_low_stress (base_road,target_road);
+CREATE INDEX idx_neighborhood_rchblrdslowstrss_b ON generated.neighborhood_reachable_roads_low_stress (base_road);
+CREATE INDEX idx_neighborhood_rchblrdslowstrss_t ON generated.neighborhood_reachable_roads_low_stress (target_road);
+ANALYZE generated.neighborhood_reachable_roads_low_stress (base_road,target_road);

--- a/connectivity/school_roads.sql
+++ b/connectivity/school_roads.sql
@@ -51,6 +51,6 @@ AND     NOT EXISTS (
             WHERE   schools.id = r.school_id
         );
 
-CREATE INDEX idx_neighborhood_schlrds_schlid ON generated.neighborhood_school_roads (school_id);
-CREATE INDEX idx_neighborhood_schlrds_rdid ON generated.neighborhood_school_roads (road_id);
+CREATE INDEX IF NOT EXISTS idx_neighborhood_schlrds_schlid ON generated.neighborhood_school_roads (school_id);
+CREATE INDEX IF NOT EXISTS idx_neighborhood_schlrds_rdid ON generated.neighborhood_school_roads (road_id);
 ANALYZE generated.neighborhood_school_roads (school_id, road_id);

--- a/connectivity/school_roads.sql
+++ b/connectivity/school_roads.sql
@@ -1,24 +1,24 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-DROP TABLE IF EXISTS generated.cambridge_school_roads;
+DROP TABLE IF EXISTS generated.neighborhood_school_roads;
 
-CREATE TABLE generated.cambridge_school_roads (
+CREATE TABLE generated.neighborhood_school_roads (
     id SERIAL PRIMARY KEY,
     school_id INT,
     road_id INT
 );
 
 -- polygons take any road within 50 feet
-INSERT INTO generated.cambridge_school_roads (
+INSERT INTO generated.neighborhood_school_roads (
     school_id,
     road_id
 )
 SELECT  schools.id,
         ways.road_id
-FROM    cambridge_schools schools,
-        cambridge_ways ways
+FROM    neighborhood_schools schools,
+        neighborhood_ways ways
 WHERE   EXISTS (
             SELECT  1
             FROM    neighborhood_boundary AS b
@@ -28,18 +28,18 @@ AND     schools.geom_poly IS NOT NULL
 AND     ST_DWithin(schools.geom_poly,ways.geom,50);
 
 -- points take the nearest road
-INSERT INTO generated.cambridge_school_roads (
+INSERT INTO generated.neighborhood_school_roads (
     school_id,
     road_id
 )
 SELECT  schools.id,
         (
             SELECT      ways.road_id
-            FROM        cambridge_ways ways
+            FROM        neighborhood_ways ways
             ORDER BY    ST_Distance(ways.geom,schools.geom_pt) ASC
             LIMIT       1
         )
-FROM    cambridge_schools schools
+FROM    neighborhood_schools schools
 WHERE   EXISTS (
             SELECT  1
             FROM    neighborhood_boundary AS b
@@ -47,10 +47,10 @@ WHERE   EXISTS (
         )
 AND     NOT EXISTS (
             SELECT  1
-            FROM    cambridge_school_roads r
+            FROM    neighborhood_school_roads r
             WHERE   schools.id = r.school_id
         );
 
-CREATE INDEX idx_cambridge_schlrds_schlid ON generated.cambridge_school_roads (school_id);
-CREATE INDEX idx_cambridge_schlrds_rdid ON generated.cambridge_school_roads (road_id);
-ANALYZE generated.cambridge_school_roads (school_id, road_id);
+CREATE INDEX idx_neighborhood_schlrds_schlid ON generated.neighborhood_school_roads (school_id);
+CREATE INDEX idx_neighborhood_schlrds_rdid ON generated.neighborhood_school_roads (road_id);
+ANALYZE generated.neighborhood_school_roads (school_id, road_id);

--- a/connectivity/schools.sql
+++ b/connectivity/schools.sql
@@ -1,6 +1,8 @@
 ----------------------------------------
 -- INPUTS
 -- location: neighborhood
+-- proj: :nb_output_srid psql var must be set before running this script,
+--       e.g. psql -v nb_output_srid=4326 -f schools.sql
 ----------------------------------------
 DROP TABLE IF EXISTS generated.neighborhood_schools;
 
@@ -10,8 +12,8 @@ CREATE TABLE generated.neighborhood_schools (
     school_name TEXT,
     pop_low_stress INT,
     pop_high_stress INT,
-    geom_pt geometry(point,2249),
-    geom_poly geometry(polygon,2249)
+    geom_pt geometry(point, :nb_output_srid),
+    geom_poly geometry(polygon, :nb_output_srid)
 );
 CREATE INDEX sidx_neighborhood_schools_geompt ON neighborhood_schools USING GIST (geom_pt);
 CREATE INDEX sidx_neighborhood_schools_geomply ON neighborhood_schools USING GIST (geom_poly);

--- a/connectivity/schools.sql
+++ b/connectivity/schools.sql
@@ -1,10 +1,10 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-DROP TABLE IF EXISTS generated.cambridge_schools;
+DROP TABLE IF EXISTS generated.neighborhood_schools;
 
-CREATE TABLE generated.cambridge_schools (
+CREATE TABLE generated.neighborhood_schools (
     id SERIAL PRIMARY KEY,
     osm_id BIGINT,
     school_name TEXT,
@@ -13,40 +13,40 @@ CREATE TABLE generated.cambridge_schools (
     geom_pt geometry(point,2249),
     geom_poly geometry(polygon,2249)
 );
-CREATE INDEX sidx_cambridge_schools_geompt ON cambridge_schools USING GIST (geom_pt);
-CREATE INDEX sidx_cambridge_schools_geomply ON cambridge_schools USING GIST (geom_poly);
+CREATE INDEX sidx_neighborhood_schools_geompt ON neighborhood_schools USING GIST (geom_pt);
+CREATE INDEX sidx_neighborhood_schools_geomply ON neighborhood_schools USING GIST (geom_poly);
 
 -- insert points from polygons
-INSERT INTO generated.cambridge_schools (
+INSERT INTO generated.neighborhood_schools (
     osm_id, school_name, geom_pt, geom_poly
 )
 SELECT  osm_id,
         name,
         ST_Centroid(way),
         way
-FROM    cambridge_osm_full_polygon
+FROM    neighborhood_osm_full_polygon
 WHERE   amenity = 'school';
 
 -- remove subareas that are mistakenly designated as amenity=school
-DELETE FROM generated.cambridge_schools
+DELETE FROM generated.neighborhood_schools
 WHERE   EXISTS (
             SELECT  1
-            FROM    generated.cambridge_schools s
-            WHERE   ST_Contains(s.geom_poly,cambridge_schools.geom_poly)
-            AND     s.id != generated.cambridge_schools.id
+            FROM    generated.neighborhood_schools s
+            WHERE   ST_Contains(s.geom_poly,neighborhood_schools.geom_poly)
+            AND     s.id != generated.neighborhood_schools.id
 );
 
 -- insert points
-INSERT INTO generated.cambridge_schools (
+INSERT INTO generated.neighborhood_schools (
     osm_id, school_name, geom_pt
 )
 SELECT  osm_id,
         name,
         way
-FROM    cambridge_osm_full_point
+FROM    neighborhood_osm_full_point
 WHERE   amenity = 'school'
 AND     NOT EXISTS (
             SELECT  1
-            FROM    cambridge_schools s
-            WHERE   ST_Intersects(s.geom_poly,cambridge_osm_full_point.way)
+            FROM    neighborhood_schools s
+            WHERE   ST_Intersects(s.geom_poly,neighborhood_osm_full_point.way)
         );

--- a/drop_tables.sh
+++ b/drop_tables.sh
@@ -1,49 +1,50 @@
 #!/usr/bin/env bash
 
 # vars
-DBHOST='192.168.1.144'
-DBNAME='people_for_bikes'
-OSMPREFIX='cambridge'
+NB_POSTGRESQL_HOST="${NB_POSTGRESQL_HOST:-127.0.0.1}"
+NB_POSTGRESQL_DB="${NB_POSTGRESQL_DB:-pfb}"
+NB_POSTGRESQL_USER="${NB_POSTGRESQL_USER:-gis}"
+NB_POSTGRESQL_PASSWORD="${NB_POSTGRESQL_PASSWORD:-gis}"
 
 # drop old tables
 echo 'Dropping old tables'
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_ways;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_ways_intersections;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_relations_ways;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_osm_nodes;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_osm_relations;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_osm_way_classes;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_osm_way_tags;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_osm_way_types;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS scratch.${OSMPREFIX}_cycwys_ways;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS scratch.${OSMPREFIX}_cycwys_ways_vertices_pgr;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS scratch.${OSMPREFIX}_cycwys_relations_ways;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS scratch.${OSMPREFIX}_cycwys_osm_nodes;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS scratch.${OSMPREFIX}_cycwys_osm_relations;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS scratch.${OSMPREFIX}_cycwys_osm_way_classes;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS scratch.${OSMPREFIX}_cycwys_osm_way_tags;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS scratch.${OSMPREFIX}_cycwys_osm_way_types;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_osm_full_line;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_osm_full_point;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_osm_full_polygon;"
-psql -h $DBHOST -U gis -d ${DBNAME} \
-  -c "DROP TABLE IF EXISTS received.${OSMPREFIX}_osm_full_roads;"
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -c "DROP TABLE IF EXISTS received.neighborhood_ways;"
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -c "DROP TABLE IF EXISTS received.neighborhood_ways_intersections;"
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -c "DROP TABLE IF EXISTS received.neighborhood_relations_ways;"
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -c "DROP TABLE IF EXISTS received.neighborhood_osm_nodes;"
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -c "DROP TABLE IF EXISTS received.neighborhood_osm_relations;"
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -c "DROP TABLE IF EXISTS received.neighborhood_osm_way_classes;"
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -c "DROP TABLE IF EXISTS received.neighborhood_osm_way_tags;"
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -c "DROP TABLE IF EXISTS received.neighborhood_osm_way_types;"
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -c "DROP TABLE IF EXISTS scratch.neighborhood_cycwys_ways;"
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -c "DROP TABLE IF EXISTS scratch.neighborhood_cycwys_ways_vertices_pgr;"
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -c "DROP TABLE IF EXISTS scratch.neighborhood_cycwys_relations_ways;"
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -c "DROP TABLE IF EXISTS scratch.neighborhood_cycwys_osm_nodes;"
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -c "DROP TABLE IF EXISTS scratch.neighborhood_cycwys_osm_relations;"
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -c "DROP TABLE IF EXISTS scratch.neighborhood_cycwys_osm_way_classes;"
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -c "DROP TABLE IF EXISTS scratch.neighborhood_cycwys_osm_way_tags;"
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -c "DROP TABLE IF EXISTS scratch.neighborhood_cycwys_osm_way_types;"
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -c "DROP TABLE IF EXISTS received.neighborhood_osm_full_line;"
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -c "DROP TABLE IF EXISTS received.neighborhood_osm_full_point;"
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -c "DROP TABLE IF EXISTS received.neighborhood_osm_full_polygon;"
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -c "DROP TABLE IF EXISTS received.neighborhood_osm_full_roads;"

--- a/functional_class.sql
+++ b/functional_class.sql
@@ -1,13 +1,13 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-UPDATE  cambridge_ways SET functional_class = NULL;
+UPDATE  neighborhood_ways SET functional_class = NULL;
 
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     functional_class = osm.highway
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     osm.highway IN (
             'motorway',
             'tertiary',
@@ -23,63 +23,63 @@ AND     osm.highway IN (
             'living_street'
 );                          -- note that we're leaving out "road"
 
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     functional_class = 'tertiary'
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     osm.highway = 'unclassified';
 
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     functional_class = 'track'
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     osm.highway = 'track'
 AND     osm.tracktype = 'grade1';
 
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     functional_class = 'path'
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     osm.highway IN ('cycleway','path');
 
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     functional_class = 'path'
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     osm.highway = 'footway'
 AND     osm.bicycle IN ('yes','permissive')
 AND     (osm.access IS NULL OR osm.access NOT IN ('no','private'));
 
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     functional_class = 'living_street'
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     osm.highway = 'pedestrian'
 AND     osm.bicycle IN ('yes','permissive')
 AND     (osm.access IS NULL OR osm.access NOT IN ('no','private'));
 
 -- remove stuff that we don't want to route over
-DELETE FROM cambridge_ways WHERE functional_class IS NULL;
+DELETE FROM neighborhood_ways WHERE functional_class IS NULL;
 
 -- remove orphans
-DELETE FROM cambridge_ways
+DELETE FROM neighborhood_ways
 WHERE   NOT EXISTS (
             SELECT  1
-            FROM    cambridge_ways w
-            WHERE   cambridge_ways.intersection_to IN (w.intersection_to,w.intersection_from)
-            AND     w.road_id != cambridge_ways.road_id
+            FROM    neighborhood_ways w
+            WHERE   neighborhood_ways.intersection_to IN (w.intersection_to,w.intersection_from)
+            AND     w.road_id != neighborhood_ways.road_id
 )
 AND     NOT EXISTS (
             SELECT  1
-            FROM    cambridge_ways w
-            WHERE   cambridge_ways.intersection_from IN (w.intersection_to,w.intersection_from)
-            AND     w.road_id != cambridge_ways.road_id
+            FROM    neighborhood_ways w
+            WHERE   neighborhood_ways.intersection_from IN (w.intersection_to,w.intersection_from)
+            AND     w.road_id != neighborhood_ways.road_id
 );
 
 -- remove obsolete intersections
-DELETE FROM cambridge_ways_intersections
+DELETE FROM neighborhood_ways_intersections
 WHERE NOT EXISTS (
     SELECT  1
-    FROM    cambridge_ways w
+    FROM    neighborhood_ways w
     WHERE   int_id IN (w.intersection_to,w.intersection_from)
 );

--- a/import.sh
+++ b/import.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+cd `dirname "${0}"`
+
+if [[ -n "${PFB_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+"
+Usage: $(basename "$0") <path to boundary file> <state abbrev of boundary> <state fips of boundary>
+
+Import all necessary files to run the analysis. See the scripts this calls for specific
+ENV configuration options.
+
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ] || [ -z "${1:-}" ]
+    then
+        usage
+    else
+        ./import_neighborhood.sh "${1}" "${3}"
+        ./import_jobs.sh "${2}"
+        ./import_osm.sh
+    fi
+fi

--- a/import_osm.sh
+++ b/import_osm.sh
@@ -6,7 +6,7 @@ NB_POSTGRESQL_HOST="${NB_POSTGRESQL_HOST:-127.0.0.1}"
 NB_POSTGRESQL_DB="${NB_POSTGRESQL_DB:-pfb}"
 NB_POSTGRESQL_USER="${NB_POSTGRESQL_USER:-gis}"
 NB_POSTGRESQL_PASSWORD="${NB_POSTGRESQL_PASSWORD:-gis}"
-NB_OSMFILE="${NB_OSMFILE:-/vagrant/data/cambridge.osm}"
+NB_OSMFILE="${NB_OSMFILE:-/vagrant/data/neighborhood.osm}"
 
 # drop old tables
 echo 'Dropping old tables'

--- a/import_osm.sh
+++ b/import_osm.sh
@@ -6,43 +6,42 @@ NB_POSTGRESQL_HOST="${NB_POSTGRESQL_HOST:-127.0.0.1}"
 NB_POSTGRESQL_DB="${NB_POSTGRESQL_DB:-pfb}"
 NB_POSTGRESQL_USER="${NB_POSTGRESQL_USER:-gis}"
 NB_POSTGRESQL_PASSWORD="${NB_POSTGRESQL_PASSWORD:-gis}"
-NB_OSMPREFIX="${NB_OSMPREFIX:-cambridge}"
 NB_OSMFILE="${NB_OSMFILE:-/vagrant/data/cambridge.osm}"
 
 # drop old tables
 echo 'Dropping old tables'
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_ways;"
+  -c "DROP TABLE IF EXISTS received.neighborhood_ways;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_ways_intersections;"
+  -c "DROP TABLE IF EXISTS received.neighborhood_ways_intersections;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_relations_ways;"
+  -c "DROP TABLE IF EXISTS received.neighborhood_relations_ways;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_osm_nodes;"
+  -c "DROP TABLE IF EXISTS received.neighborhood_osm_nodes;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_osm_relations;"
+  -c "DROP TABLE IF EXISTS received.neighborhood_osm_relations;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_osm_way_classes;"
+  -c "DROP TABLE IF EXISTS received.neighborhood_osm_way_classes;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_osm_way_tags;"
+  -c "DROP TABLE IF EXISTS received.neighborhood_osm_way_tags;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_osm_way_types;"
+  -c "DROP TABLE IF EXISTS received.neighborhood_osm_way_types;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "DROP TABLE IF EXISTS scratch.${NB_OSMPREFIX}_cycwys_ways;"
+  -c "DROP TABLE IF EXISTS scratch.neighborhood_cycwys_ways;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "DROP TABLE IF EXISTS scratch.${NB_OSMPREFIX}_cycwys_ways_vertices_pgr;"
+  -c "DROP TABLE IF EXISTS scratch.neighborhood_cycwys_ways_vertices_pgr;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "DROP TABLE IF EXISTS scratch.${NB_OSMPREFIX}_cycwys_relations_ways;"
+  -c "DROP TABLE IF EXISTS scratch.neighborhood_cycwys_relations_ways;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "DROP TABLE IF EXISTS scratch.${NB_OSMPREFIX}_cycwys_osm_nodes;"
+  -c "DROP TABLE IF EXISTS scratch.neighborhood_cycwys_osm_nodes;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "DROP TABLE IF EXISTS scratch.${NB_OSMPREFIX}_cycwys_osm_relations;"
+  -c "DROP TABLE IF EXISTS scratch.neighborhood_cycwys_osm_relations;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "DROP TABLE IF EXISTS scratch.${NB_OSMPREFIX}_cycwys_osm_way_classes;"
+  -c "DROP TABLE IF EXISTS scratch.neighborhood_cycwys_osm_way_classes;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "DROP TABLE IF EXISTS scratch.${NB_OSMPREFIX}_cycwys_osm_way_tags;"
+  -c "DROP TABLE IF EXISTS scratch.neighborhood_cycwys_osm_way_tags;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "DROP TABLE IF EXISTS scratch.${NB_OSMPREFIX}_cycwys_osm_way_types;"
+  -c "DROP TABLE IF EXISTS scratch.neighborhood_cycwys_osm_way_types;"
 
 # import the osm with highways
 osm2pgrouting \
@@ -51,7 +50,7 @@ osm2pgrouting \
   --dbname ${NB_POSTGRESQL_DB} \
   --username ${NB_POSTGRESQL_USER} \
   --schema received \
-  --prefix ${NB_OSMPREFIX}_ \
+  --prefix neighborhood_ \
   --conf ./mapconfig_highway.xml \
   --clean
 
@@ -62,50 +61,50 @@ osm2pgrouting \
   --dbname ${NB_POSTGRESQL_DB} \
   --username ${NB_POSTGRESQL_USER} \
   --schema scratch \
-  --prefix ${NB_OSMPREFIX}_cycwys_ \
+  --prefix neighborhood_cycwys_ \
   --conf ./mapconfig_cycleway.xml \
   --clean
 
 # rename a few tables
 echo 'Renaming tables'
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE received.${NB_OSMPREFIX}_ways_vertices_pgr RENAME TO ${NB_OSMPREFIX}_ways_intersections;"
+  -c "ALTER TABLE received.neighborhood_ways_vertices_pgr RENAME TO neighborhood_ways_intersections;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE received.${NB_OSMPREFIX}_ways_intersections RENAME CONSTRAINT vertex_id TO ${NB_OSMPREFIX}_vertex_id;"
+  -c "ALTER TABLE received.neighborhood_ways_intersections RENAME CONSTRAINT vertex_id TO neighborhood_vertex_id;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE received.osm_nodes RENAME TO ${NB_OSMPREFIX}_osm_nodes;"
+  -c "ALTER TABLE received.osm_nodes RENAME TO neighborhood_osm_nodes;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE received.${NB_OSMPREFIX}_osm_nodes RENAME CONSTRAINT node_id TO ${NB_OSMPREFIX}_node_id;"
+  -c "ALTER TABLE received.neighborhood_osm_nodes RENAME CONSTRAINT node_id TO neighborhood_node_id;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE received.osm_relations RENAME TO ${NB_OSMPREFIX}_osm_relations;"
+  -c "ALTER TABLE received.osm_relations RENAME TO neighborhood_osm_relations;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE received.osm_way_classes RENAME TO ${NB_OSMPREFIX}_osm_way_classes;"
+  -c "ALTER TABLE received.osm_way_classes RENAME TO neighborhood_osm_way_classes;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE received.${NB_OSMPREFIX}_osm_way_classes RENAME CONSTRAINT osm_way_classes_pkey TO ${NB_OSMPREFIX}_osm_way_classes_pkey;"
+  -c "ALTER TABLE received.neighborhood_osm_way_classes RENAME CONSTRAINT osm_way_classes_pkey TO neighborhood_osm_way_classes_pkey;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE received.osm_way_tags RENAME TO ${NB_OSMPREFIX}_osm_way_tags;"
+  -c "ALTER TABLE received.osm_way_tags RENAME TO neighborhood_osm_way_tags;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE received.osm_way_types RENAME TO ${NB_OSMPREFIX}_osm_way_types;"
+  -c "ALTER TABLE received.osm_way_types RENAME TO neighborhood_osm_way_types;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE received.${NB_OSMPREFIX}_osm_way_types RENAME CONSTRAINT osm_way_types_pkey TO ${NB_OSMPREFIX}_osm_way_types_pkey;"
+  -c "ALTER TABLE received.neighborhood_osm_way_types RENAME CONSTRAINT osm_way_types_pkey TO neighborhood_osm_way_types_pkey;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE scratch.${NB_OSMPREFIX}_cycwys_ways_vertices_pgr RENAME CONSTRAINT vertex_id TO ${NB_OSMPREFIX}_vertex_id;"
+  -c "ALTER TABLE scratch.neighborhood_cycwys_ways_vertices_pgr RENAME CONSTRAINT vertex_id TO neighborhood_vertex_id;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE scratch.osm_nodes RENAME TO ${NB_OSMPREFIX}_cycwys_osm_nodes;"
+  -c "ALTER TABLE scratch.osm_nodes RENAME TO neighborhood_cycwys_osm_nodes;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE scratch.${NB_OSMPREFIX}_cycwys_osm_nodes RENAME CONSTRAINT node_id TO ${NB_OSMPREFIX}_node_id;"
+  -c "ALTER TABLE scratch.neighborhood_cycwys_osm_nodes RENAME CONSTRAINT node_id TO neighborhood_node_id;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE scratch.osm_relations RENAME TO ${NB_OSMPREFIX}_cycwys_osm_relations;"
+  -c "ALTER TABLE scratch.osm_relations RENAME TO neighborhood_cycwys_osm_relations;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE scratch.osm_way_classes RENAME TO ${NB_OSMPREFIX}_cycwys_osm_way_classes;"
+  -c "ALTER TABLE scratch.osm_way_classes RENAME TO neighborhood_cycwys_osm_way_classes;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE scratch.${NB_OSMPREFIX}_cycwys_osm_way_classes RENAME CONSTRAINT osm_way_classes_pkey TO ${NB_OSMPREFIX}_osm_way_classes_pkey;"
+  -c "ALTER TABLE scratch.neighborhood_cycwys_osm_way_classes RENAME CONSTRAINT osm_way_classes_pkey TO neighborhood_osm_way_classes_pkey;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE scratch.osm_way_tags RENAME TO ${NB_OSMPREFIX}_cycwys_osm_way_tags;"
+  -c "ALTER TABLE scratch.osm_way_tags RENAME TO neighborhood_cycwys_osm_way_tags;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE scratch.osm_way_types RENAME TO ${NB_OSMPREFIX}_cycwys_osm_way_types;"
+  -c "ALTER TABLE scratch.osm_way_types RENAME TO neighborhood_cycwys_osm_way_types;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE scratch.${NB_OSMPREFIX}_cycwys_osm_way_types RENAME CONSTRAINT osm_way_types_pkey TO ${NB_OSMPREFIX}_osm_way_types_pkey;"
+  -c "ALTER TABLE scratch.neighborhood_cycwys_osm_way_types RENAME CONSTRAINT osm_way_types_pkey TO neighborhood_osm_way_types_pkey;"
 
 # import full osm to fill out additional data needs
 # not met by osm2pgrouting
@@ -113,13 +112,13 @@ psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
 # drop old tables
 echo 'Dropping old tables'
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_osm_full_line;"
+  -c "DROP TABLE IF EXISTS received.neighborhood_osm_full_line;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_osm_full_point;"
+  -c "DROP TABLE IF EXISTS received.neighborhood_osm_full_point;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_osm_full_polygon;"
+  -c "DROP TABLE IF EXISTS received.neighborhood_osm_full_polygon;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "DROP TABLE IF EXISTS received.${NB_OSMPREFIX}_osm_full_roads;"
+  -c "DROP TABLE IF EXISTS received.neighborhood_osm_full_roads;"
 
 # import
 osm2pgsql \
@@ -128,7 +127,7 @@ osm2pgsql \
   --port 5432 \
   --create \
   --database "${NB_POSTGRESQL_DB}" \
-  --prefix "${NB_OSMPREFIX}_osm_full" \
+  --prefix "neighborhood_osm_full" \
   --proj 2249 \
   --style ./pfb.style \
   "${NB_OSMFILE}"
@@ -136,13 +135,13 @@ osm2pgsql \
 # move the full osm tables to the received schema
 echo 'Moving tables to received schema'
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE generated.${NB_OSMPREFIX}_osm_full_line SET SCHEMA received;"
+  -c "ALTER TABLE generated.neighborhood_osm_full_line SET SCHEMA received;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE generated.${NB_OSMPREFIX}_osm_full_point SET SCHEMA received;"
+  -c "ALTER TABLE generated.neighborhood_osm_full_point SET SCHEMA received;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE generated.${NB_OSMPREFIX}_osm_full_polygon SET SCHEMA received;"
+  -c "ALTER TABLE generated.neighborhood_osm_full_polygon SET SCHEMA received;"
 psql -h $NB_POSTGRESQL_HOST -U ${NB_POSTGRESQL_USER} -d ${NB_POSTGRESQL_DB} \
-  -c "ALTER TABLE generated.${NB_OSMPREFIX}_osm_full_roads SET SCHEMA received;"
+  -c "ALTER TABLE generated.neighborhood_osm_full_roads SET SCHEMA received;"
 
 # process tables
 echo 'Updating field names'

--- a/lanes.sql
+++ b/lanes.sql
@@ -1,32 +1,32 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-UPDATE  cambridge_ways SET ft_lanes = NULL, tf_lanes = NULL;
+UPDATE  neighborhood_ways SET ft_lanes = NULL, tf_lanes = NULL;
 
 -- forward
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     ft_lanes = substring(osm."lanes:forward" FROM '\d+')::INT
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     ft_lanes IS NULL
 AND     osm."lanes:forward" IS NOT NULL;
 
 -- backward
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     tf_lanes = substring(osm."lanes:backward" FROM '\d+')::INT
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     tf_lanes IS NULL
 AND     osm."lanes:backward" IS NOT NULL;
 
 -- all lanes (no direction given)
 -- two way
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     ft_lanes = floor(substring(osm.lanes FROM '\d+')::FLOAT / 2),
         tf_lanes = floor(substring(osm.lanes FROM '\d+')::FLOAT / 2)
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     tf_lanes IS NULL
 AND     ft_lanes IS NULL
 AND     one_way_car NOT IN ('ft','tf')
@@ -34,17 +34,17 @@ AND     osm.lanes IS NOT NULL;
 
 -- all lanes (no direction given)
 -- one way
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     ft_lanes = substring(osm.lanes FROM '\d+')::INT
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     one_way_car = 'ft'
 AND     ft_lanes IS NULL
 AND     osm.lanes IS NOT NULL;
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     tf_lanes = substring(osm.lanes FROM '\d+')::INT
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     one_way_car = 'tf'
 AND     tf_lanes IS NULL
 AND     osm.lanes IS NOT NULL;

--- a/legs.sql
+++ b/legs.sql
@@ -1,10 +1,10 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-UPDATE  received.cambridge_ways_intersections
+UPDATE  received.neighborhood_ways_intersections
 SET     legs = (
             SELECT  COUNT(road_id)
-            FROM    cambridge_ways
-            WHERE   cambridge_ways_intersections.int_id IN (intersection_from,intersection_to)
+            FROM    neighborhood_ways
+            WHERE   neighborhood_ways_intersections.int_id IN (intersection_from,intersection_to)
 );

--- a/one_way.sql
+++ b/one_way.sql
@@ -1,19 +1,19 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-UPDATE  cambridge_ways SET one_way_car = NULL;
+UPDATE  neighborhood_ways SET one_way_car = NULL;
 
 -- ft direction
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     one_way_car = 'ft'
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     trim(osm.oneway) IN ('1','yes');
 
 -- tf direction
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     one_way_car = 'tf'
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     trim(osm.oneway) = '-1';

--- a/park.sql
+++ b/park.sql
@@ -1,11 +1,11 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-UPDATE  cambridge_ways SET ft_park = NULL, tf_park = NULL;
+UPDATE  neighborhood_ways SET ft_park = NULL, tf_park = NULL;
 
 -- both
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     ft_park = CASE  WHEN osm."parking:lane:both" = 'parallel' THEN 1
                         WHEN osm."parking:lane:both" = 'paralell' THEN 1
                         WHEN osm."parking:lane:both" = 'diagonal' THEN 1
@@ -20,11 +20,11 @@ SET     ft_park = CASE  WHEN osm."parking:lane:both" = 'parallel' THEN 1
                         WHEN osm."parking:lane:both" = 'no_parking' THEN 0
                         WHEN osm."parking:lane:both" = 'no_stopping' THEN 0
                         END
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id;
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id;
 
 -- right
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     ft_park = CASE  WHEN osm."parking:lane:right" = 'parallel' THEN 1
                         WHEN osm."parking:lane:right" = 'paralell' THEN 1
                         WHEN osm."parking:lane:right" = 'diagonal' THEN 1
@@ -32,11 +32,11 @@ SET     ft_park = CASE  WHEN osm."parking:lane:right" = 'parallel' THEN 1
                         WHEN osm."parking:lane:right" = 'no_parking' THEN 0
                         WHEN osm."parking:lane:right" = 'no_stopping' THEN 0
                         END
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id;
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id;
 
 -- left
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     tf_park = CASE  WHEN osm."parking:lane:left" = 'parallel' THEN 1
                         WHEN osm."parking:lane:left" = 'paralell' THEN 1
                         WHEN osm."parking:lane:left" = 'diagonal' THEN 1
@@ -44,5 +44,5 @@ SET     tf_park = CASE  WHEN osm."parking:lane:left" = 'parallel' THEN 1
                         WHEN osm."parking:lane:left" = 'no_parking' THEN 0
                         WHEN osm."parking:lane:left" = 'no_stopping' THEN 0
                         END
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id;
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id;

--- a/paths.sql
+++ b/paths.sql
@@ -1,11 +1,11 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-DROP TABLE IF EXISTS generated.cambridge_paths;
-DROP INDEX IF EXISTS idx_cambridge_ways_path_id;
+DROP TABLE IF EXISTS generated.neighborhood_paths;
+DROP INDEX IF EXISTS idx_neighborhood_ways_path_id;
 
-CREATE TABLE generated.cambridge_paths (
+CREATE TABLE generated.neighborhood_paths (
     path_id SERIAL PRIMARY KEY,
     geom geometry(multilinestring,2249),
     path_length INTEGER,
@@ -13,7 +13,7 @@ CREATE TABLE generated.cambridge_paths (
 );
 
 -- combine contiguous paths
-INSERT INTO cambridge_paths (geom)
+INSERT INTO neighborhood_paths (geom)
 SELECT  ST_CollectionExtract(
             ST_SetSRID(
                 unnest(ST_ClusterIntersecting(geom)),
@@ -21,15 +21,15 @@ SELECT  ST_CollectionExtract(
             ),
             2   --linestrings
         )
-FROM    cambridge_ways
+FROM    neighborhood_ways
 WHERE   functional_class = 'path';
 
 -- get raw lengths
-UPDATE  cambridge_paths
+UPDATE  neighborhood_paths
 SET     path_length = ST_Length(geom);
 
 -- get bounding box lengths
-UPDATE  cambridge_paths
+UPDATE  neighborhood_paths
 SET     bbox_length = ST_Length(
             ST_SetSRID(
                 ST_MakeLine(
@@ -41,25 +41,25 @@ SET     bbox_length = ST_Length(
         );
 
 -- set path_id on each road segment (if path)
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     path_id = (
             SELECT  paths.path_id
-            FROM    cambridge_paths paths
-            WHERE   ST_Intersects(cambridge_ways.geom,paths.geom)
-            AND     ST_CoveredBy(cambridge_ways.geom,paths.geom)
+            FROM    neighborhood_paths paths
+            WHERE   ST_Intersects(neighborhood_ways.geom,paths.geom)
+            AND     ST_CoveredBy(neighborhood_ways.geom,paths.geom)
             LIMIT   1
         )
 WHERE   functional_class = 'path';
 
 -- get stragglers
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     path_id = paths.path_id
-FROM    cambridge_paths paths
-WHERE   cambridge_ways.functional_class = 'path'
-AND     cambridge_ways.path_id IS NULL
-AND     ST_Intersects(cambridge_ways.geom,paths.geom)
-AND     ST_CoveredBy(cambridge_ways.geom,ST_Buffer(paths.geom,1));
+FROM    neighborhood_paths paths
+WHERE   neighborhood_ways.functional_class = 'path'
+AND     neighborhood_ways.path_id IS NULL
+AND     ST_Intersects(neighborhood_ways.geom,paths.geom)
+AND     ST_CoveredBy(neighborhood_ways.geom,ST_Buffer(paths.geom,1));
 
 -- set index
-CREATE INDEX idx_cambridge_ways_path_id ON cambridge_ways (path_id);
-ANALYZE cambridge_ways (path_id);
+CREATE INDEX idx_neighborhood_ways_path_id ON neighborhood_ways (path_id);
+ANALYZE neighborhood_ways (path_id);

--- a/paths.sql
+++ b/paths.sql
@@ -1,13 +1,15 @@
 ----------------------------------------
 -- INPUTS
 -- location: neighborhood
+-- proj: :nb_output_srid psql var must be set before running this script,
+--       e.g. psql -v nb_output_srid=4326 -f paths.sql
 ----------------------------------------
 DROP TABLE IF EXISTS generated.neighborhood_paths;
 DROP INDEX IF EXISTS idx_neighborhood_ways_path_id;
 
 CREATE TABLE generated.neighborhood_paths (
     path_id SERIAL PRIMARY KEY,
-    geom geometry(multilinestring,2249),
+    geom geometry(multilinestring, :nb_output_srid),
     path_length INTEGER,
     bbox_length INTEGER
 );
@@ -17,7 +19,7 @@ INSERT INTO neighborhood_paths (geom)
 SELECT  ST_CollectionExtract(
             ST_SetSRID(
                 unnest(ST_ClusterIntersecting(geom)),
-                2249
+                :nb_output_srid
             ),
             2   --linestrings
         )
@@ -36,7 +38,7 @@ SET     bbox_length = ST_Length(
                     ST_MakePoint(ST_XMin(geom), ST_YMin(geom)),
                     ST_MakePoint(ST_XMax(geom), ST_YMax(geom))
                 ),
-                2249
+                :nb_output_srid
             )
         );
 

--- a/prepare_tables.sql
+++ b/prepare_tables.sql
@@ -1,7 +1,8 @@
 ----------------------------------------
 -- INPUTS
 -- location: neighborhood
--- proj: 2249
+-- proj: :nb_output_srid psql var must be set before running this script,
+--       e.g. psql -v nb_output_srid=4326 -f prepare_tables.sql
 ----------------------------------------
 
 -- add tdg_id field to roads
@@ -44,12 +45,12 @@ ALTER TABLE neighborhood_ways_intersections RENAME COLUMN id TO int_id;
 ALTER TABLE neighborhood_ways_intersections RENAME COLUMN the_geom TO geom;
 
 -- reproject
-ALTER TABLE neighborhood_ways ALTER COLUMN geom TYPE geometry(linestring,2249)
-USING ST_Transform(geom,2249);
-ALTER TABLE neighborhood_cycwys_ways ALTER COLUMN the_geom TYPE geometry(linestring,2249)
-USING ST_Transform(the_geom,2249);
-ALTER TABLE neighborhood_ways_intersections ALTER COLUMN geom TYPE geometry(point,2249)
-USING ST_Transform(geom,2249);
+ALTER TABLE neighborhood_ways ALTER COLUMN geom TYPE geometry(linestring,:nb_output_srid)
+USING ST_Transform(geom,:nb_output_srid);
+ALTER TABLE neighborhood_cycwys_ways ALTER COLUMN the_geom TYPE geometry(linestring,:nb_output_srid)
+USING ST_Transform(the_geom,:nb_output_srid);
+ALTER TABLE neighborhood_ways_intersections ALTER COLUMN geom TYPE geometry(point,:nb_output_srid)
+USING ST_Transform(geom,:nb_output_srid);
 
 -- add columns
 ALTER TABLE neighborhood_ways ADD COLUMN functional_class TEXT;

--- a/prepare_tables.sql
+++ b/prepare_tables.sql
@@ -1,111 +1,111 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 -- proj: 2249
 ----------------------------------------
 
 -- add tdg_id field to roads
-ALTER TABLE cambridge_ways ADD COLUMN tdg_id TEXT DEFAULT uuid_generate_v4();
+ALTER TABLE neighborhood_ways ADD COLUMN tdg_id TEXT DEFAULT uuid_generate_v4();
 
 -- drop unnecessary columns
-ALTER TABLE cambridge_ways DROP COLUMN class_id;
-ALTER TABLE cambridge_ways DROP COLUMN length;
-ALTER TABLE cambridge_ways DROP COLUMN length_m;
-ALTER TABLE cambridge_ways DROP COLUMN x1;
-ALTER TABLE cambridge_ways DROP COLUMN y1;
-ALTER TABLE cambridge_ways DROP COLUMN x2;
-ALTER TABLE cambridge_ways DROP COLUMN y2;
-ALTER TABLE cambridge_ways DROP COLUMN cost;
-ALTER TABLE cambridge_ways DROP COLUMN reverse_cost;
-ALTER TABLE cambridge_ways DROP COLUMN cost_s;
-ALTER TABLE cambridge_ways DROP COLUMN reverse_cost_s;
-ALTER TABLE cambridge_ways DROP COLUMN rule;
-ALTER TABLE cambridge_ways DROP COLUMN maxspeed_forward;
-ALTER TABLE cambridge_ways DROP COLUMN maxspeed_backward;
-ALTER TABLE cambridge_ways DROP COLUMN source_osm;
-ALTER TABLE cambridge_ways DROP COLUMN target_osm;
-ALTER TABLE cambridge_ways DROP COLUMN priority;
-ALTER TABLE cambridge_ways DROP COLUMN one_way;
+ALTER TABLE neighborhood_ways DROP COLUMN class_id;
+ALTER TABLE neighborhood_ways DROP COLUMN length;
+ALTER TABLE neighborhood_ways DROP COLUMN length_m;
+ALTER TABLE neighborhood_ways DROP COLUMN x1;
+ALTER TABLE neighborhood_ways DROP COLUMN y1;
+ALTER TABLE neighborhood_ways DROP COLUMN x2;
+ALTER TABLE neighborhood_ways DROP COLUMN y2;
+ALTER TABLE neighborhood_ways DROP COLUMN cost;
+ALTER TABLE neighborhood_ways DROP COLUMN reverse_cost;
+ALTER TABLE neighborhood_ways DROP COLUMN cost_s;
+ALTER TABLE neighborhood_ways DROP COLUMN reverse_cost_s;
+ALTER TABLE neighborhood_ways DROP COLUMN rule;
+ALTER TABLE neighborhood_ways DROP COLUMN maxspeed_forward;
+ALTER TABLE neighborhood_ways DROP COLUMN maxspeed_backward;
+ALTER TABLE neighborhood_ways DROP COLUMN source_osm;
+ALTER TABLE neighborhood_ways DROP COLUMN target_osm;
+ALTER TABLE neighborhood_ways DROP COLUMN priority;
+ALTER TABLE neighborhood_ways DROP COLUMN one_way;
 
-ALTER TABLE cambridge_ways_intersections DROP COLUMN cnt;
-ALTER TABLE cambridge_ways_intersections DROP COLUMN chk;
-ALTER TABLE cambridge_ways_intersections DROP COLUMN ein;
-ALTER TABLE cambridge_ways_intersections DROP COLUMN eout;
-ALTER TABLE cambridge_ways_intersections DROP COLUMN lon;
-ALTER TABLE cambridge_ways_intersections DROP COLUMN lat;
+ALTER TABLE neighborhood_ways_intersections DROP COLUMN cnt;
+ALTER TABLE neighborhood_ways_intersections DROP COLUMN chk;
+ALTER TABLE neighborhood_ways_intersections DROP COLUMN ein;
+ALTER TABLE neighborhood_ways_intersections DROP COLUMN eout;
+ALTER TABLE neighborhood_ways_intersections DROP COLUMN lon;
+ALTER TABLE neighborhood_ways_intersections DROP COLUMN lat;
 
 -- change column names
-ALTER TABLE cambridge_ways RENAME COLUMN gid TO road_id;
-ALTER TABLE cambridge_ways RENAME COLUMN the_geom TO geom;
-ALTER TABLE cambridge_ways RENAME COLUMN source TO intersection_from;
-ALTER TABLE cambridge_ways RENAME COLUMN target TO intersection_to;
+ALTER TABLE neighborhood_ways RENAME COLUMN gid TO road_id;
+ALTER TABLE neighborhood_ways RENAME COLUMN the_geom TO geom;
+ALTER TABLE neighborhood_ways RENAME COLUMN source TO intersection_from;
+ALTER TABLE neighborhood_ways RENAME COLUMN target TO intersection_to;
 
-ALTER TABLE cambridge_ways_intersections RENAME COLUMN id TO int_id;
-ALTER TABLE cambridge_ways_intersections RENAME COLUMN the_geom TO geom;
+ALTER TABLE neighborhood_ways_intersections RENAME COLUMN id TO int_id;
+ALTER TABLE neighborhood_ways_intersections RENAME COLUMN the_geom TO geom;
 
 -- reproject
-ALTER TABLE cambridge_ways ALTER COLUMN geom TYPE geometry(linestring,2249)
+ALTER TABLE neighborhood_ways ALTER COLUMN geom TYPE geometry(linestring,2249)
 USING ST_Transform(geom,2249);
-ALTER TABLE cambridge_cycwys_ways ALTER COLUMN the_geom TYPE geometry(linestring,2249)
+ALTER TABLE neighborhood_cycwys_ways ALTER COLUMN the_geom TYPE geometry(linestring,2249)
 USING ST_Transform(the_geom,2249);
-ALTER TABLE cambridge_ways_intersections ALTER COLUMN geom TYPE geometry(point,2249)
+ALTER TABLE neighborhood_ways_intersections ALTER COLUMN geom TYPE geometry(point,2249)
 USING ST_Transform(geom,2249);
 
 -- add columns
-ALTER TABLE cambridge_ways ADD COLUMN functional_class TEXT;
-ALTER TABLE cambridge_ways ADD COLUMN path_id INTEGER;
-ALTER TABLE cambridge_ways ADD COLUMN speed_limit INT;
-ALTER TABLE cambridge_ways ADD COLUMN one_way_car VARCHAR(2);
-ALTER TABLE cambridge_ways ADD COLUMN one_way VARCHAR(2);
-ALTER TABLE cambridge_ways ADD COLUMN width_ft INT;
-ALTER TABLE cambridge_ways ADD COLUMN ft_bike_infra TEXT;
-ALTER TABLE cambridge_ways ADD COLUMN tf_bike_infra TEXT;
-ALTER TABLE cambridge_ways ADD COLUMN ft_lanes INT;
-ALTER TABLE cambridge_ways ADD COLUMN tf_lanes INT;
-ALTER TABLE cambridge_ways ADD COLUMN ft_park INT;
-ALTER TABLE cambridge_ways ADD COLUMN tf_park INT;
-ALTER TABLE cambridge_ways ADD COLUMN ft_seg_stress INT;
-ALTER TABLE cambridge_ways ADD COLUMN ft_int_stress INT;
-ALTER TABLE cambridge_ways ADD COLUMN tf_seg_stress INT;
-ALTER TABLE cambridge_ways ADD COLUMN tf_int_stress INT;
+ALTER TABLE neighborhood_ways ADD COLUMN functional_class TEXT;
+ALTER TABLE neighborhood_ways ADD COLUMN path_id INTEGER;
+ALTER TABLE neighborhood_ways ADD COLUMN speed_limit INT;
+ALTER TABLE neighborhood_ways ADD COLUMN one_way_car VARCHAR(2);
+ALTER TABLE neighborhood_ways ADD COLUMN one_way VARCHAR(2);
+ALTER TABLE neighborhood_ways ADD COLUMN width_ft INT;
+ALTER TABLE neighborhood_ways ADD COLUMN ft_bike_infra TEXT;
+ALTER TABLE neighborhood_ways ADD COLUMN tf_bike_infra TEXT;
+ALTER TABLE neighborhood_ways ADD COLUMN ft_lanes INT;
+ALTER TABLE neighborhood_ways ADD COLUMN tf_lanes INT;
+ALTER TABLE neighborhood_ways ADD COLUMN ft_park INT;
+ALTER TABLE neighborhood_ways ADD COLUMN tf_park INT;
+ALTER TABLE neighborhood_ways ADD COLUMN ft_seg_stress INT;
+ALTER TABLE neighborhood_ways ADD COLUMN ft_int_stress INT;
+ALTER TABLE neighborhood_ways ADD COLUMN tf_seg_stress INT;
+ALTER TABLE neighborhood_ways ADD COLUMN tf_int_stress INT;
 
 -- indexes
-CREATE INDEX idx_cambridge_ways_osm ON cambridge_ways (osm_id);
-CREATE INDEX idx_cambridge_ways_ints_osm ON cambridge_ways_intersections (osm_id);
-CREATE INDEX idx_cambridge_fullways ON cambridge_osm_full_line (osm_id);
-CREATE INDEX idx_cambridge_fullpoints ON cambridge_osm_full_point (osm_id);
-ANALYZE cambridge_ways (osm_id,geom);
-ANALYZE cambridge_cycwys_ways (the_geom);
-ANALYZE cambridge_ways_intersections (osm_id);
-ANALYZE cambridge_osm_full_line (osm_id);
-ANALYZE cambridge_osm_full_point (osm_id);
+CREATE INDEX idx_neighborhood_ways_osm ON neighborhood_ways (osm_id);
+CREATE INDEX idx_neighborhood_ways_ints_osm ON neighborhood_ways_intersections (osm_id);
+CREATE INDEX idx_neighborhood_fullways ON neighborhood_osm_full_line (osm_id);
+CREATE INDEX idx_neighborhood_fullpoints ON neighborhood_osm_full_point (osm_id);
+ANALYZE neighborhood_ways (osm_id,geom);
+ANALYZE neighborhood_cycwys_ways (the_geom);
+ANALYZE neighborhood_ways_intersections (osm_id);
+ANALYZE neighborhood_osm_full_line (osm_id);
+ANALYZE neighborhood_osm_full_point (osm_id);
 
 -- add in cycleway data that is missing from first osm2pgrouting call
-INSERT INTO cambridge_ways (
+INSERT INTO neighborhood_ways (
     name, intersection_from, intersection_to, osm_id, geom
 )
 SELECT  name,
         (SELECT     i.int_id
-        FROM        cambridge_ways_intersections i
-        WHERE       i.geom <#> cambridge_cycwys_ways.the_geom < 20
-        ORDER BY    ST_Distance(ST_StartPoint(cambridge_cycwys_ways.the_geom),i.geom) ASC
+        FROM        neighborhood_ways_intersections i
+        WHERE       i.geom <#> neighborhood_cycwys_ways.the_geom < 20
+        ORDER BY    ST_Distance(ST_StartPoint(neighborhood_cycwys_ways.the_geom),i.geom) ASC
         LIMIT       1),
         (SELECT     i.int_id
-        FROM        cambridge_ways_intersections i
-        WHERE       i.geom <#> cambridge_cycwys_ways.the_geom < 20
-        ORDER BY    ST_Distance(ST_EndPoint(cambridge_cycwys_ways.the_geom),i.geom) ASC
+        FROM        neighborhood_ways_intersections i
+        WHERE       i.geom <#> neighborhood_cycwys_ways.the_geom < 20
+        ORDER BY    ST_Distance(ST_EndPoint(neighborhood_cycwys_ways.the_geom),i.geom) ASC
         LIMIT       1),
         osm_id,
         the_geom
-FROM    cambridge_cycwys_ways
+FROM    neighborhood_cycwys_ways
 WHERE   NOT EXISTS (
             SELECT  1
-            FROM    cambridge_ways w2
-            WHERE   w2.osm_id = cambridge_cycwys_ways.osm_id
+            FROM    neighborhood_ways w2
+            WHERE   w2.osm_id = neighborhood_cycwys_ways.osm_id
 );
 
 -- setup intersection table
-ALTER TABLE cambridge_ways_intersections ADD COLUMN legs INT;
-ALTER TABLE cambridge_ways_intersections ADD COLUMN signalized BOOLEAN;
-ALTER TABLE cambridge_ways_intersections ADD COLUMN stops BOOLEAN;
-CREATE INDEX idx_cambridge_ints_stop ON cambridge_ways_intersections (signalized,stops);
+ALTER TABLE neighborhood_ways_intersections ADD COLUMN legs INT;
+ALTER TABLE neighborhood_ways_intersections ADD COLUMN signalized BOOLEAN;
+ALTER TABLE neighborhood_ways_intersections ADD COLUMN stops BOOLEAN;
+CREATE INDEX idx_neighborhood_ints_stop ON neighborhood_ways_intersections (signalized,stops);

--- a/run_connectivity.sh
+++ b/run_connectivity.sh
@@ -6,6 +6,7 @@ NB_POSTGRESQL_HOST="${NB_POSTGRESQL_HOST:-127.0.0.1}"
 NB_POSTGRESQL_DB="${NB_POSTGRESQL_DB:-pfb}"
 NB_POSTGRESQL_USER="${NB_POSTGRESQL_USER:-gis}"
 NB_POSTGRESQL_PASSWORD="${NB_POSTGRESQL_PASSWORD:-gis}"
+NB_OUTPUT_SRID="${NB_OUTPUT_SRID:-4326}"
 
 psql -h "${DBHOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -c "SELECT tdgMakeNetwork('neighborhood_ways');"
@@ -38,7 +39,7 @@ psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_D
   -f connectivity/access_jobs.sql
 
 /usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
-  -f connectivity/schools.sql
+  -v nb_output_srid="${NB_OUTPUT_SRID}" -f connectivity/schools.sql
 
 /usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f connectivity/school_roads.sql

--- a/run_connectivity.sh
+++ b/run_connectivity.sh
@@ -2,51 +2,52 @@
 
 cd `dirname $0`
 
-DBHOST='127.0.0.1'
-DBNAME='pfb'
-OSMPREFIX='cambridge'
+NB_POSTGRESQL_HOST="${NB_POSTGRESQL_HOST:-127.0.0.1}"
+NB_POSTGRESQL_DB="${NB_POSTGRESQL_DB:-pfb}"
+NB_POSTGRESQL_USER="${NB_POSTGRESQL_USER:-gis}"
+NB_POSTGRESQL_PASSWORD="${NB_POSTGRESQL_PASSWORD:-gis}"
 
-# psql -h "${DBHOST}" -U gis -d "${DBNAME}" \
-#   -c "SELECT tdgMakeNetwork('${OSMPREFIX}_ways');"
+psql -h "${DBHOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -c "SELECT tdgMakeNetwork('neighborhood_ways');"
 
-# psql -h "${DBHOST}" -U gis -d "${DBNAME}" \
-#   -c "SELECT tdgNetworkCostFromDistance('${OSMPREFIX}_ways');"
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -c "SELECT tdgNetworkCostFromDistance('neighborhood_ways');"
 
-/usr/bin/time -v psql -h "${DBHOST}" -U gis -d "${DBNAME}" \
+/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f connectivity/census_blocks.sql
 
-/usr/bin/time -v psql -h "${DBHOST}" -U gis -d "${DBNAME}" \
+/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f connectivity/census_block_roads.sql
 
-/usr/bin/time -v psql -h "${DBHOST}" -U gis -d "${DBNAME}" \
+/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f connectivity/reachable_roads_high_stress.sql
 
-/usr/bin/time -v psql -h "${DBHOST}" -U gis -d "${DBNAME}" \
+/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f connectivity/reachable_roads_low_stress.sql
 
-/usr/bin/time -v psql -h "${DBHOST}" -U gis -d "${DBNAME}" \
+/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f connectivity/connected_census_blocks.sql
 
-/usr/bin/time -v psql -h "${DBHOST}" -U gis -d "${DBNAME}" \
+/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f connectivity/access_population.sql
 
-/usr/bin/time -v psql -h "${DBHOST}" -U gis -d "${DBNAME}" \
+/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f connectivity/census_block_jobs.sql
 
-/usr/bin/time -v psql -h "${DBHOST}" -U gis -d "${DBNAME}" \
+/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f connectivity/access_jobs.sql
 
-/usr/bin/time -v psql -h "${DBHOST}" -U gis -d "${DBNAME}" \
+/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f connectivity/schools.sql
 
-/usr/bin/time -v psql -h "${DBHOST}" -U gis -d "${DBNAME}" \
+/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f connectivity/school_roads.sql
 
-/usr/bin/time -v psql -h "${DBHOST}" -U gis -d "${DBNAME}" \
+/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f connectivity/connected_census_blocks_schools.sql
 
-/usr/bin/time -v psql -h "${DBHOST}" -U gis -d "${DBNAME}" \
+/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f connectivity/access_schools.sql
 
-/usr/bin/time -v psql -h "${DBHOST}" -U gis -d "${DBNAME}" \
+/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -f connectivity/overall_scores.sql

--- a/signalized.sql
+++ b/signalized.sql
@@ -1,27 +1,27 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-UPDATE cambridge_ways_intersections SET signalized = 'f';
+UPDATE neighborhood_ways_intersections SET signalized = 'f';
 
-UPDATE  cambridge_ways_intersections
+UPDATE  neighborhood_ways_intersections
 SET     signalized = 't'
-FROM    cambridge_osm_full_point osm
-WHERE   cambridge_ways_intersections.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_point osm
+WHERE   neighborhood_ways_intersections.osm_id = osm.osm_id
 AND     osm.highway = 'traffic_signals';
 
-UPDATE  cambridge_ways_intersections
+UPDATE  neighborhood_ways_intersections
 SET     signalized = 't'
-FROM    cambridge_ways,
-        cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
-AND     int_id = cambridge_ways.intersection_to
+FROM    neighborhood_ways,
+        neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
+AND     int_id = neighborhood_ways.intersection_to
 AND     osm."traffic_signals:direction" = 'forward';
 
-UPDATE  cambridge_ways_intersections
+UPDATE  neighborhood_ways_intersections
 SET     signalized = 't'
-FROM    cambridge_ways,
-        cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
-AND     int_id = cambridge_ways.intersection_from
+FROM    neighborhood_ways,
+        neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
+AND     int_id = neighborhood_ways.intersection_from
 AND     osm."traffic_signals:direction" = 'backward';

--- a/speed_limit.sql
+++ b/speed_limit.sql
@@ -1,11 +1,11 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-UPDATE  cambridge_ways SET speed_limit = NULL;
+UPDATE  neighborhood_ways SET speed_limit = NULL;
 
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     speed_limit = substring(osm.maxspeed from '\d+')::INT
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     osm.maxspeed LIKE '% mph';

--- a/stops.sql
+++ b/stops.sql
@@ -1,12 +1,12 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-UPDATE cambridge_ways_intersections SET stops = 'f';
+UPDATE neighborhood_ways_intersections SET stops = 'f';
 
-UPDATE  cambridge_ways_intersections
+UPDATE  neighborhood_ways_intersections
 SET     stops = 't'
-FROM    cambridge_osm_full_point osm
-WHERE   cambridge_ways_intersections.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_point osm
+WHERE   neighborhood_ways_intersections.osm_id = osm.osm_id
 AND     osm.highway = 'stop'
 AND     osm.stop = 'all';

--- a/stress_lesser_ints.sql
+++ b/stress_lesser_ints.sql
@@ -1,19 +1,19 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-UPDATE  cambridge_ways SET ft_int_stress = 1, tf_int_stress = 1
+UPDATE  neighborhood_ways SET ft_int_stress = 1, tf_int_stress = 1
 WHERE   functional_class IN ('residential','living_street','track','path');
 
 -- ft
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     ft_int_stress = 3
 WHERE   functional_class IN ('residential','living_street','track','path')
 AND     EXISTS (
             SELECT  1
-            FROM    cambridge_ways w
-            WHERE   cambridge_ways.intersection_to IN (w.intersection_to,w.intersection_from)
-            AND     COALESCE(cambridge_ways.name,'a') != COALESCE(w.name,'b')
+            FROM    neighborhood_ways w
+            WHERE   neighborhood_ways.intersection_to IN (w.intersection_to,w.intersection_from)
+            AND     COALESCE(neighborhood_ways.name,'a') != COALESCE(w.name,'b')
             AND     CASE
                     WHEN w.functional_class IN ('motorway','trunk','primary')
                         THEN    CASE
@@ -62,14 +62,14 @@ AND     EXISTS (
 );
 
 -- tf
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     tf_int_stress = 3
 WHERE   functional_class IN ('residential','living_street','track','path')
 AND     EXISTS (
             SELECT  1
-            FROM    cambridge_ways w
-            WHERE   cambridge_ways.intersection_from IN (w.intersection_to,w.intersection_from)
-            AND     COALESCE(cambridge_ways.name,'a') != COALESCE(w.name,'b')
+            FROM    neighborhood_ways w
+            WHERE   neighborhood_ways.intersection_from IN (w.intersection_to,w.intersection_from)
+            AND     COALESCE(neighborhood_ways.name,'a') != COALESCE(w.name,'b')
             AND     CASE
                     WHEN w.functional_class IN ('motorway','trunk','primary')
                         THEN    CASE

--- a/stress_link_ints.sql
+++ b/stress_link_ints.sql
@@ -1,6 +1,6 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-UPDATE  cambridge_ways SET ft_int_stress = 1, tf_int_stress = 1
+UPDATE  neighborhood_ways SET ft_int_stress = 1, tf_int_stress = 1
 WHERE   functional_class LIKE '%_link';

--- a/stress_living_street.sql
+++ b/stress_living_street.sql
@@ -1,11 +1,11 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-UPDATE  cambridge_ways SET ft_seg_stress = NULL, tf_seg_stress = NULL
+UPDATE  neighborhood_ways SET ft_seg_stress = NULL, tf_seg_stress = NULL
 WHERE   functional_class = 'living_street';
 
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     ft_seg_stress = 1,
         tf_seg_stress = 1
 WHERE   functional_class = 'living_street';

--- a/stress_motorway-trunk.sql
+++ b/stress_motorway-trunk.sql
@@ -1,9 +1,9 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-UPDATE  cambridge_ways SET ft_seg_stress = NULL, tf_seg_stress = NULL
+UPDATE  neighborhood_ways SET ft_seg_stress = NULL, tf_seg_stress = NULL
 WHERE   functional_class IN ('motorway','motorway_link','trunk','trunk_link');
 
-UPDATE  cambridge_ways SET ft_seg_stress = 3, tf_seg_stress = 3
+UPDATE  neighborhood_ways SET ft_seg_stress = 3, tf_seg_stress = 3
 WHERE   functional_class IN ('motorway','motorway_link','trunk','trunk_link');

--- a/stress_motorway-trunk_ints.sql
+++ b/stress_motorway-trunk_ints.sql
@@ -1,7 +1,7 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
 -- assume low stress, since these juncions would always be controlled or free flowing
-UPDATE  cambridge_ways SET ft_int_stress = 1, tf_int_stress = 1
+UPDATE  neighborhood_ways SET ft_int_stress = 1, tf_int_stress = 1
 WHERE   functional_class IN ('motorway','trunk');

--- a/stress_one_way_reset.sql
+++ b/stress_one_way_reset.sql
@@ -1,7 +1,7 @@
 -- reset opposite stress for one-way
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     ft_seg_stress = NULL
 WHERE   one_way = 'tf';
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     tf_seg_stress = NULL
 WHERE   one_way = 'ft';

--- a/stress_path.sql
+++ b/stress_path.sql
@@ -1,11 +1,11 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-UPDATE  cambridge_ways SET ft_seg_stress = NULL, tf_seg_stress = NULL
+UPDATE  neighborhood_ways SET ft_seg_stress = NULL, tf_seg_stress = NULL
 WHERE   functional_class = 'path';
 
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     ft_seg_stress = 1,
         tf_seg_stress = 1
 WHERE   functional_class = 'path';

--- a/stress_primary.sql
+++ b/stress_primary.sql
@@ -1,12 +1,12 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-UPDATE  cambridge_ways SET ft_seg_stress = NULL, tf_seg_stress = NULL
+UPDATE  neighborhood_ways SET ft_seg_stress = NULL, tf_seg_stress = NULL
 WHERE   functional_class IN ('primary','primary_link');
 
 -- ft direction
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     ft_seg_stress =
             CASE
             WHEN ft_bike_infra = 'track' THEN 1
@@ -51,7 +51,7 @@ SET     ft_seg_stress =
 WHERE   functional_class IN ('primary','primary_link');
 
 -- tf direction
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     tf_seg_stress =
             CASE
             WHEN tf_bike_infra = 'track' THEN 1

--- a/stress_primary_ints.sql
+++ b/stress_primary_ints.sql
@@ -1,7 +1,7 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
 -- assume low stress, since these juncions would always be controlled or free flowing
-UPDATE  cambridge_ways SET ft_int_stress = 1, tf_int_stress = 1
+UPDATE  neighborhood_ways SET ft_int_stress = 1, tf_int_stress = 1
 WHERE   functional_class = 'primary';

--- a/stress_residential.sql
+++ b/stress_residential.sql
@@ -1,16 +1,16 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 -- notes: residential streets with bike lanes of any type
 --        are scored as tertiary streets
 ----------------------------------------
-UPDATE  cambridge_ways SET ft_seg_stress = NULL, tf_seg_stress = NULL
+UPDATE  neighborhood_ways SET ft_seg_stress = NULL, tf_seg_stress = NULL
 WHERE   functional_class = 'residential'
 AND     (ft_bike_infra IS NULL OR ft_bike_infra NOT IN ('track','buffered_lane','lane'))
 AND     (tf_bike_infra IS NULL OR tf_bike_infra NOT IN ('track','buffered_lane','lane'));
 
 -- no additional information
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     ft_seg_stress = 1,
         tf_seg_stress = 1
 WHERE   functional_class = 'residential'
@@ -18,13 +18,13 @@ AND     (ft_bike_infra IS NULL OR ft_bike_infra NOT IN ('track','buffered_lane',
 AND     (tf_bike_infra IS NULL OR tf_bike_infra NOT IN ('track','buffered_lane','lane'));
 
 -- stress increase for multiple lanes or high speeds
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     ft_seg_stress = 3
 WHERE   functional_class = 'residential'
 AND     (ft_bike_infra IS NULL OR ft_bike_infra NOT IN ('track','buffered_lane','lane'))
 AND     (tf_bike_infra IS NULL OR tf_bike_infra NOT IN ('track','buffered_lane','lane'))
 AND     (ft_lanes > 1 OR speed_limit > 30);
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     tf_seg_stress = 3
 WHERE   functional_class = 'residential'
 AND     (ft_bike_infra IS NULL OR ft_bike_infra NOT IN ('track','buffered_lane','lane'))
@@ -32,7 +32,7 @@ AND     (tf_bike_infra IS NULL OR tf_bike_infra NOT IN ('track','buffered_lane',
 AND     (tf_lanes > 1 OR speed_limit > 30);
 
 -- stress increase for narrow one way and parking on both sides
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     ft_seg_stress = 2,
         tf_seg_stress = 2
 WHERE   functional_class = 'residential'

--- a/stress_secondary.sql
+++ b/stress_secondary.sql
@@ -1,12 +1,12 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-UPDATE  cambridge_ways SET ft_seg_stress = NULL, tf_seg_stress = NULL
+UPDATE  neighborhood_ways SET ft_seg_stress = NULL, tf_seg_stress = NULL
 WHERE   functional_class IN ('secondary','secondary_link');
 
 -- ft direction
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     ft_seg_stress =
             CASE
             WHEN ft_bike_infra = 'track' THEN 1
@@ -51,7 +51,7 @@ SET     ft_seg_stress =
 WHERE   functional_class IN ('secondary','secondary_link');
 
 -- tf direction
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     tf_seg_stress =
             CASE
             WHEN tf_bike_infra = 'track' THEN 1

--- a/stress_secondary_ints.sql
+++ b/stress_secondary_ints.sql
@@ -1,19 +1,19 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-UPDATE  cambridge_ways SET ft_int_stress = 1, tf_int_stress = 1
+UPDATE  neighborhood_ways SET ft_int_stress = 1, tf_int_stress = 1
 WHERE   functional_class = 'secondary';
 
 -- ft
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     ft_int_stress = 3
 WHERE   functional_class = 'secondary'
 AND     EXISTS (
             SELECT  1
-            FROM    cambridge_ways w
-            WHERE   cambridge_ways.intersection_to IN (w.intersection_to,w.intersection_from)
-            AND     COALESCE(cambridge_ways.name,'a') != COALESCE(w.name,'b')
+            FROM    neighborhood_ways w
+            WHERE   neighborhood_ways.intersection_to IN (w.intersection_to,w.intersection_from)
+            AND     COALESCE(neighborhood_ways.name,'a') != COALESCE(w.name,'b')
             AND     CASE
                     WHEN w.functional_class IN ('motorway','trunk','primary')
                         THEN    CASE
@@ -48,14 +48,14 @@ AND     EXISTS (
 );
 
 -- tf
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     tf_int_stress = 3
 WHERE   functional_class = 'secondary'
 AND     EXISTS (
             SELECT  1
-            FROM    cambridge_ways w
-            WHERE   cambridge_ways.intersection_from IN (w.intersection_to,w.intersection_from)
-            AND     COALESCE(cambridge_ways.name,'a') != COALESCE(w.name,'b')
+            FROM    neighborhood_ways w
+            WHERE   neighborhood_ways.intersection_from IN (w.intersection_to,w.intersection_from)
+            AND     COALESCE(neighborhood_ways.name,'a') != COALESCE(w.name,'b')
             AND     CASE
                     WHEN w.functional_class IN ('motorway','trunk','primary')
                         THEN    CASE

--- a/stress_tertiary.sql
+++ b/stress_tertiary.sql
@@ -1,16 +1,16 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 -- notes: this includes residential streets that have bike lanes
 --        of any type
 ----------------------------------------
-UPDATE  cambridge_ways SET ft_seg_stress = NULL, tf_seg_stress = NULL
+UPDATE  neighborhood_ways SET ft_seg_stress = NULL, tf_seg_stress = NULL
 WHERE   functional_class IN ('tertiary','tertiary_link')
 OR      (functional_class = 'residential' AND ft_bike_infra IN ('track','buffered_lane','lane'))
 OR      (functional_class = 'residential' AND tf_bike_infra IN ('track','buffered_lane','lane'));
 
 -- ft direction
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     ft_seg_stress =
             CASE
             WHEN ft_bike_infra = 'track' THEN 1
@@ -68,7 +68,7 @@ OR      (functional_class = 'residential' AND ft_bike_infra IN ('track','buffere
 OR      (functional_class = 'residential' AND tf_bike_infra IN ('track','buffered_lane','lane'));
 
 -- tf direction
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     tf_seg_stress =
             CASE
             WHEN tf_bike_infra = 'track' THEN 1

--- a/stress_tertiary_ints.sql
+++ b/stress_tertiary_ints.sql
@@ -1,19 +1,19 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-UPDATE  cambridge_ways SET ft_int_stress = 1, tf_int_stress = 1
+UPDATE  neighborhood_ways SET ft_int_stress = 1, tf_int_stress = 1
 WHERE   functional_class = 'tertiary';
 
 -- ft
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     ft_int_stress = 3
 WHERE   functional_class = 'tertiary'
 AND     EXISTS (
             SELECT  1
-            FROM    cambridge_ways w
-            WHERE   cambridge_ways.intersection_to IN (w.intersection_to,w.intersection_from)
-            AND     COALESCE(cambridge_ways.name,'a') != COALESCE(w.name,'b')
+            FROM    neighborhood_ways w
+            WHERE   neighborhood_ways.intersection_to IN (w.intersection_to,w.intersection_from)
+            AND     COALESCE(neighborhood_ways.name,'a') != COALESCE(w.name,'b')
             AND     CASE
                     WHEN w.functional_class IN ('motorway','trunk','primary')
                         THEN    CASE
@@ -62,14 +62,14 @@ AND     EXISTS (
 );
 
 -- tf
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     tf_int_stress = 3
 WHERE   functional_class = 'tertiary'
 AND     EXISTS (
             SELECT  1
-            FROM    cambridge_ways w
-            WHERE   cambridge_ways.intersection_from IN (w.intersection_to,w.intersection_from)
-            AND     COALESCE(cambridge_ways.name,'a') != COALESCE(w.name,'b')
+            FROM    neighborhood_ways w
+            WHERE   neighborhood_ways.intersection_from IN (w.intersection_to,w.intersection_from)
+            AND     COALESCE(neighborhood_ways.name,'a') != COALESCE(w.name,'b')
             AND     CASE
                     WHEN w.functional_class IN ('motorway','trunk','primary')
                         THEN    CASE

--- a/stress_track.sql
+++ b/stress_track.sql
@@ -1,11 +1,11 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-UPDATE  cambridge_ways SET ft_seg_stress = NULL, tf_seg_stress = NULL
+UPDATE  neighborhood_ways SET ft_seg_stress = NULL, tf_seg_stress = NULL
 WHERE   functional_class = 'track';
 
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     ft_seg_stress = 1,
         tf_seg_stress = 1
 WHERE   functional_class = 'track';

--- a/width_ft.sql
+++ b/width_ft.sql
@@ -1,31 +1,31 @@
 ----------------------------------------
 -- INPUTS
--- location: cambridge
+-- location: neighborhood
 ----------------------------------------
-UPDATE  cambridge_ways SET width_ft = NULL;
+UPDATE  neighborhood_ways SET width_ft = NULL;
 
 -- feet
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     width_ft = substring(osm.width from '\d+\.?\d?\d?')::FLOAT
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     osm.width IS NOT NULL
 AND     osm.width LIKE '% ft';
 
 -- meters
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     width_ft = 3.28084 * substring(osm.width from '\d+\.?\d?\d?')::FLOAT
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     osm.width IS NOT NULL
 AND     osm.width LIKE '% m';
 
 -- no units (default=meters)
 -- N.B. we weed out anything more than 20, since that's likely either bogus
 -- or not in meters
-UPDATE  cambridge_ways
+UPDATE  neighborhood_ways
 SET     width_ft = 3.28084 * substring(osm.width from '\d+\.?\d?\d?')::FLOAT
-FROM    cambridge_osm_full_line osm
-WHERE   cambridge_ways.osm_id = osm.osm_id
+FROM    neighborhood_osm_full_line osm
+WHERE   neighborhood_ways.osm_id = osm.osm_id
 AND     osm.width IS NOT NULL
 AND     substring(osm.width from '\d+\.?\d?\d?')::FLOAT < 20;


### PR DESCRIPTION
Addresses azavea/pfb-network-connectivity#6 by globally renaming 'cambridge' to 'neighborhood' in all scripts files.

Makes connectivity scripts idempotent so that multiple runs can be triggered without having to modify the database manually in between runs. 

Adds a wrapper import script that calls each of the three existing import scripts to save copy pasta.
