### PR TITLE
Performance improvement for Connect Census Block query

### DIFF
--- a/connectivity/census_blocks.sql
+++ b/connectivity/census_blocks.sql
@@ -16,4 +16,5 @@ ALTER TABLE neighborhood_census_blocks ADD COLUMN IF NOT EXISTS rec_low_stress I
 ALTER TABLE neighborhood_census_blocks ADD COLUMN IF NOT EXISTS rec_high_stress INT;
 
 CREATE INDEX IF NOT EXISTS idx_neighborhood_blocks10 ON neighborhood_census_blocks (blockid10);
-ANALYZE neighborhood_census_blocks (blockid10);
+CREATE INDEX IF NOT EXISTS idx_neighborhood_geom ON neighborhood_census_blocks USING GIST (geom);
+ANALYZE neighborhood_census_blocks;

--- a/connectivity/connected_census_blocks.sql
+++ b/connectivity/connected_census_blocks.sql
@@ -14,36 +14,31 @@ CREATE TABLE generated.neighborhood_connected_census_blocks (
     high_stress_cost INT
 );
 
-INSERT INTO generated.neighborhood_connected_census_blocks (  -- took 2 hrs on the server
+INSERT INTO generated.neighborhood_connected_census_blocks (
     source_blockid10, target_blockid10, low_stress, high_stress
 )
 SELECT  source_block.blockid10,
         target_block.blockid10,
         'f'::BOOLEAN,
         't'::BOOLEAN
-FROM    neighborhood_census_blocks source_block,
-        neighborhood_census_blocks target_block
-WHERE   EXISTS (
-            SELECT  1
-            FROM    neighborhood_boundary AS b
-            WHERE   ST_Intersects(source_block.geom,b.geom)
-        )
-AND     source_block.geom <#> target_block.geom < 11000
-AND     EXISTS (
-            SELECT  1
-            FROM    neighborhood_census_block_roads source_br,
-                    neighborhood_census_block_roads target_br,
-                    neighborhood_reachable_roads_high_stress hs
-            WHERE   source_block.blockid10 = source_br.blockid10
-            AND     target_block.blockid10 = target_br.blockid10
-            AND     hs.base_road = source_br.road_id
-            AND     hs.target_road = target_br.road_id
-        );
+FROM    neighborhood_boundary b
+JOIN    neighborhood_census_blocks source_block
+        ON  ST_Intersects(source_block.geom,b.geom)
+JOIN    neighborhood_census_blocks target_block
+        ON  source_block.geom <#> target_block.geom < 11000
+JOIN    neighborhood_census_block_roads source_br
+        ON  source_block.blockid10 = source_br.blockid10
+JOIN    neighborhood_census_block_roads target_br
+        ON  target_block.blockid10 = target_br.blockid10
+JOIN    neighborhood_reachable_roads_high_stress hs
+        ON  hs.base_road = source_br.road_id
+        AND hs.target_road = target_br.road_id
+GROUP BY source_block.blockid10, target_block.blockid10
+;
 
 -- block pair index
-CREATE INDEX idx_neighborhood_blockpairs
-ON neighborhood_connected_census_blocks (source_blockid10,target_blockid10);
-ANALYZE neighborhood_connected_census_blocks (source_blockid10,target_blockid10);
+CREATE UNIQUE INDEX idx_neighborhood_blockpairs ON neighborhood_connected_census_blocks (source_blockid10,target_blockid10);
+ANALYZE neighborhood_connected_census_blocks;
 
 -- low stress
 UPDATE  neighborhood_connected_census_blocks
@@ -82,4 +77,4 @@ AND     (
 -- stress index
 CREATE INDEX IF NOT EXISTS idx_neighborhood_blockpairs_lstress ON neighborhood_connected_census_blocks (low_stress);
 CREATE INDEX IF NOT EXISTS idx_neighborhood_blockpairs_hstress ON neighborhood_connected_census_blocks (high_stress);
-ANALYZE neighborhood_connected_census_blocks (low_stress,high_stress);
+ANALYZE neighborhood_connected_census_blocks;

--- a/connectivity/reachable_roads_high_stress.sql
+++ b/connectivity/reachable_roads_high_stress.sql
@@ -41,6 +41,6 @@ WHERE   EXISTS (
 AND     r1.road_id = v1.road_id
 AND     v2.vert_id = sheds.node;
 
-CREATE INDEX IF NOT EXISTS idx_neighborhood_rchblrdshistrss_b ON generated.neighborhood_reachable_roads_high_stress (base_road);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_neighborhood_rchblrdshistrss_b ON generated.neighborhood_reachable_roads_high_stress (base_road, target_road);
 CREATE INDEX IF NOT EXISTS idx_neighborhood_rchblrdshistrss_t ON generated.neighborhood_reachable_roads_high_stress (target_road);
-ANALYZE generated.neighborhood_reachable_roads_high_stress (base_road,target_road);
+ANALYZE generated.neighborhood_reachable_roads_high_stress;


### PR DESCRIPTION
After testing appears to reduce query execution time to 8 minutes for this block in isolation, and about 22 minutes in whole. At the surface seems to generate the same results (And judging from the query it appears it should), but it should be compared to a full run of the previous, multi-hour version to ensure correctness.