### PR TITLE
Closes #11: Parameterize buffer distance

### DIFF
--- a/connectivity/connected_census_blocks.sql
+++ b/connectivity/connected_census_blocks.sql
@@ -1,6 +1,8 @@
 ----------------------------------------
 -- INPUTS
 -- location: neighborhood
+-- :nb_boundary_buffer psql var must be set before running this script,
+--      e.g. psql -v nb_boundary_buffer=11000 -f connected_census_blocks.sql
 ----------------------------------------
 DROP TABLE IF EXISTS generated.neighborhood_connected_census_blocks;
 
@@ -25,7 +27,7 @@ FROM    neighborhood_boundary b
 JOIN    neighborhood_census_blocks source_block
         ON  ST_Intersects(source_block.geom,b.geom)
 JOIN    neighborhood_census_blocks target_block
-        ON  source_block.geom <#> target_block.geom < 11000
+        ON  source_block.geom <#> target_block.geom < :nb_boundary_buffer
 JOIN    neighborhood_census_block_roads source_br
         ON  source_block.blockid10 = source_br.blockid10
 JOIN    neighborhood_census_block_roads target_br
@@ -72,7 +74,7 @@ AND     (
             AND     target_blockid10 = target_br.blockid10
             AND     hs.base_road = source_br.road_id
             AND     hs.target_road = target_br.road_id
-        ),11000) <= 1.3;
+        ), :nb_boundary_buffer) <= 1.3;
 
 -- stress index
 CREATE INDEX IF NOT EXISTS idx_neighborhood_blockpairs_lstress ON neighborhood_connected_census_blocks (low_stress);

--- a/connectivity/connected_census_blocks_recreation.sql
+++ b/connectivity/connected_census_blocks_recreation.sql
@@ -1,6 +1,8 @@
 ----------------------------------------
 -- INPUTS
 -- location: neighborhood
+-- :nb_boundary_buffer psql var must be set before running this script,
+--      e.g. psql -v nb_boundary_buffer=11000 -f connected_census_blocks_recreation.sql
 ----------------------------------------
 DROP TABLE IF EXISTS generated.neighborhood_connected_census_blocks_recreation;
 
@@ -29,7 +31,7 @@ WHERE   EXISTS (
             WHERE   ST_Intersects(blocks.geom,zips.geom)
             AND     zips.zip_code = '02138'
         )
-AND     blocks.geom <#> paths.geom < 11000
+AND     blocks.geom <#> paths.geom < :nb_boundary_buffer
 AND     EXISTS (
             SELECT  1
             FROM    neighborhood_census_block_roads source_br,
@@ -84,7 +86,7 @@ AND     (
             AND     target_school_id = target_sr.school_id
             AND     hs.base_road = source_br.road_id
             AND     hs.target_road = target_sr.road_id
-        ),11000) <= 1.3;
+        ), :nb_boundary_buffer) <= 1.3;
 
 -- stress index
 CREATE INDEX idx_neighborhood_blockschl_lstress ON neighborhood_connected_census_blocks_recreation (low_stress);

--- a/connectivity/connected_census_blocks_schools.sql
+++ b/connectivity/connected_census_blocks_schools.sql
@@ -1,6 +1,8 @@
 ----------------------------------------
 -- INPUTS
 -- location: neighborhood
+-- :nb_boundary_buffer psql var must be set before running this script,
+--      e.g. psql -v nb_boundary_buffer=11000 -f connected_census_blocks_schools.sql
 ----------------------------------------
 DROP TABLE IF EXISTS generated.neighborhood_connected_census_blocks_schools;
 
@@ -28,7 +30,7 @@ WHERE   EXISTS (
             FROM    neighborhood_boundary AS b
             WHERE   ST_Intersects(blocks.geom,b.geom)
         )
-AND     blocks.geom <#> schools.geom_pt < 11000
+AND     blocks.geom <#> schools.geom_pt < :nb_boundary_buffer
 AND     EXISTS (
             SELECT  1
             FROM    neighborhood_census_block_roads source_br,
@@ -77,7 +79,7 @@ AND     (
             AND     target_school_id = target_sr.school_id
             AND     hs.base_road = source_br.road_id
             AND     hs.target_road = target_sr.road_id
-        ),11000) <= 1.3;
+        ), :nb_boundary_buffer) <= 1.3;
 
 -- stress index
 CREATE INDEX IF NOT EXISTS idx_neighborhood_blockschl_lstress ON neighborhood_connected_census_blocks_schools (low_stress);

--- a/connectivity/school_roads.sql
+++ b/connectivity/school_roads.sql
@@ -1,6 +1,8 @@
 ----------------------------------------
 -- INPUTS
 -- location: neighborhood
+-- :nb_boundary_buffer psql var must be set before running this script,
+--      e.g. psql -v nb_boundary_buffer=11000 -f school_roads.sql
 ----------------------------------------
 DROP TABLE IF EXISTS generated.neighborhood_school_roads;
 
@@ -22,7 +24,7 @@ FROM    neighborhood_schools schools,
 WHERE   EXISTS (
             SELECT  1
             FROM    neighborhood_boundary AS b
-            WHERE   ST_DWithin(b.geom, schools.geom_pt, 11000)
+            WHERE   ST_DWithin(b.geom, schools.geom_pt, :nb_boundary_buffer)
         )
 AND     schools.geom_poly IS NOT NULL
 AND     ST_DWithin(schools.geom_poly,ways.geom,50);
@@ -43,7 +45,7 @@ FROM    neighborhood_schools schools
 WHERE   EXISTS (
             SELECT  1
             FROM    neighborhood_boundary AS b
-            WHERE   ST_DWithin(b.geom, schools.geom_pt, 11000)
+            WHERE   ST_DWithin(b.geom, schools.geom_pt, :nb_boundary_buffer)
         )
 AND     NOT EXISTS (
             SELECT  1

--- a/import_neighborhood.sh
+++ b/import_neighborhood.sh
@@ -30,7 +30,8 @@ Requires passing the state FIPS ID that the neighborhood boundary is found in. e
 Optional ENV vars:
 
 NB_INPUT_SRID - Default: 4326
-NB_OUTPUT_SRID - Default: 4326
+NB_OUTPUT_SRID - Default: 4326 (Should have units of 'ft', otherwise some portions of the
+                                analysis will not work correctly)
 NB_BOUNDARY_BUFFER - Default: 0 (Units is units of NB_OUTPUT_SRID)
 NB_POSTGRESQL_HOST - Default: 127.0.0.1
 NB_POSTGRESQL_DB - Default: pfb

--- a/run_connectivity.sh
+++ b/run_connectivity.sh
@@ -7,6 +7,7 @@ NB_POSTGRESQL_DB="${NB_POSTGRESQL_DB:-pfb}"
 NB_POSTGRESQL_USER="${NB_POSTGRESQL_USER:-gis}"
 NB_POSTGRESQL_PASSWORD="${NB_POSTGRESQL_PASSWORD:-gis}"
 NB_OUTPUT_SRID="${NB_OUTPUT_SRID:-4326}"
+NB_BOUNDARY_BUFFER="${NB_BOUNDARY_BUFFER:-0}"
 
 psql -h "${DBHOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -c "SELECT tdgMakeNetwork('neighborhood_ways');"
@@ -27,6 +28,7 @@ psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_D
   -f connectivity/reachable_roads_low_stress.sql
 
 /usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -v nb_boundary_buffer="${NB_BOUNDARY_BUFFER}" \
   -f connectivity/connected_census_blocks.sql
 
 /usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
@@ -42,9 +44,11 @@ psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_D
   -v nb_output_srid="${NB_OUTPUT_SRID}" -f connectivity/schools.sql
 
 /usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -v nb_boundary_buffer="${NB_BOUNDARY_BUFFER}" \
   -f connectivity/school_roads.sql
 
 /usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -v nb_boundary_buffer="${NB_BOUNDARY_BUFFER}" \
   -f connectivity/connected_census_blocks_schools.sql
 
 /usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \


### PR DESCRIPTION
Ensures that the census block distance comparisons
are consistent across the entire analysis.

However, the analysis still requires an NB_OUTPUT_SRID where
the projection units are feet since there are other
hardcoded comparisons of other quantities.

Once this is merged I will update the parent project subcommit ref