### PR TITLE
Download OSM data via shell script

### DIFF
--- a/import_osm.sh
+++ b/import_osm.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 cd `dirname $0`
 
 NB_POSTGRESQL_HOST="${NB_POSTGRESQL_HOST:-127.0.0.1}"

--- a/run_connectivity.sh
+++ b/run_connectivity.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 cd `dirname $0`
 
 NB_POSTGRESQL_HOST="${NB_POSTGRESQL_HOST:-127.0.0.1}"


### PR DESCRIPTION
Considered moving this into a python script, which would be more familiar to more developers on the team and be easier to handle errors/debug. However, a python script would require additional dependencies and have some awkwardness in handling the downloaded file path.

So, I just left this inline instead since it was pretty straightforward. Happy to rework/reconsider this as a python script, or improve what's here (my bash-fu is pretty weak).

