### PR TITLE
Tweak OSM download to pull all data within bbox

### DIFF
--- a/import_osm.sh
+++ b/import_osm.sh
@@ -59,7 +59,7 @@ BBOX_SW_LNG=`bc <<< "$BBOX_SW_LNG - $LNG_DIFF"`
 BBOX_NE_LAT=`bc <<< "$BBOX_NE_LAT + $LAT_DIFF"`
 BBOX_NE_LNG=`bc <<< "$BBOX_NE_LNG + $LNG_DIFF"`
 # Download OSM data
-OSM_API_URL="http://www.overpass-api.de/api/xapi?way[bbox=${BBOX_SW_LNG},${BBOX_SW_LAT},${BBOX_NE_LNG},${BBOX_NE_LAT}][highway=*]"
+OSM_API_URL="http://www.overpass-api.de/api/xapi?*[bbox=${BBOX_SW_LNG},${BBOX_SW_LAT},${BBOX_NE_LNG},${BBOX_NE_LAT}]"
 OSM_TEMPDIR=`mktemp -d`
 OSM_DATA_FILE="${OSM_TEMPDIR}/overpass.osm"
 wget -O "${OSM_DATA_FILE}" "${OSM_API_URL}"


### PR DESCRIPTION
The analysis uses OSM data other than highways, such as
amenity=school. For now, while in development, assume we need
all the data within the bounding box. We can tighten up these
parameters once the analysis finalizes and we deploy the
application.

As a point of reference, the center city philly bbox pulled
15mb of data in ~60s. According to the Overpass wiki page,
we can continue to make requests to the API as long as we don't
exceed these limits:
- < 10,000 queries per day
- < 5GB download per day

http://wiki.openstreetmap.org/wiki/Overpass_API

If we do start to get near these limits, we'll need to
investigate other options for download.