### PR TITLE
Change run_connectivity to parallelize in 8 threads

### DIFF
--- a/connectivity/reachable_roads_high_stress_calc.sql
+++ b/connectivity/reachable_roads_high_stress_calc.sql
@@ -3,15 +3,6 @@
 -- location: neighborhood
 -- maximum network distsance: 10560 ft
 ----------------------------------------
-DROP TABLE IF EXISTS generated.neighborhood_reachable_roads_high_stress;
-
-CREATE TABLE generated.neighborhood_reachable_roads_high_stress (
-    id SERIAL PRIMARY KEY,
-    base_road INT,
-    target_road INT,
-    total_cost FLOAT
-);
-
 INSERT INTO generated.neighborhood_reachable_roads_high_stress (
     base_road,
     target_road,
@@ -33,7 +24,9 @@ FROM    neighborhood_ways r1,
             10560,
             directed := true
         ) sheds
-WHERE   EXISTS (
+WHERE r1.road_id % :thread_num = :thread_no
+AND
+EXISTS (
             SELECT  1
             FROM    neighborhood_boundary AS b
             WHERE   ST_Intersects(b.geom,r1.geom)
@@ -41,6 +34,3 @@ WHERE   EXISTS (
 AND     r1.road_id = v1.road_id
 AND     v2.vert_id = sheds.node;
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_neighborhood_rchblrdshistrss_b ON generated.neighborhood_reachable_roads_high_stress (base_road, target_road);
-CREATE INDEX IF NOT EXISTS idx_neighborhood_rchblrdshistrss_t ON generated.neighborhood_reachable_roads_high_stress (target_road);
-ANALYZE generated.neighborhood_reachable_roads_high_stress;

--- a/connectivity/reachable_roads_high_stress_cleanup.sql
+++ b/connectivity/reachable_roads_high_stress_cleanup.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX IF NOT EXISTS idx_neighborhood_rchblrdshistrss_b ON generated.neighborhood_reachable_roads_high_stress (base_road, target_road);
+CREATE INDEX IF NOT EXISTS idx_neighborhood_rchblrdshistrss_t ON generated.neighborhood_reachable_roads_high_stress (target_road);
+ANALYZE generated.neighborhood_reachable_roads_high_stress;

--- a/connectivity/reachable_roads_high_stress_prep.sql
+++ b/connectivity/reachable_roads_high_stress_prep.sql
@@ -1,0 +1,13 @@
+----------------------------------------
+-- INPUTS
+-- location: neighborhood
+-- maximum network distsance: 10560 ft
+----------------------------------------
+DROP TABLE IF EXISTS generated.neighborhood_reachable_roads_high_stress;
+
+CREATE TABLE generated.neighborhood_reachable_roads_high_stress (
+    id SERIAL PRIMARY KEY,
+    base_road INT,
+    target_road INT,
+    total_cost FLOAT
+);

--- a/connectivity/reachable_roads_low_stress_calc.sql
+++ b/connectivity/reachable_roads_low_stress_calc.sql
@@ -3,15 +3,6 @@
 -- location: neighborhood
 -- maximum network distsance: 10560 ft
 ----------------------------------------
-DROP TABLE IF EXISTS generated.neighborhood_reachable_roads_low_stress;
-
-CREATE TABLE generated.neighborhood_reachable_roads_low_stress (
-    id SERIAL PRIMARY KEY,
-    base_road INT,
-    target_road INT,
-    total_cost FLOAT
-);
-
 INSERT INTO generated.neighborhood_reachable_roads_low_stress (
     base_road,
     target_road,
@@ -34,14 +25,12 @@ FROM    neighborhood_ways r1,
             10560,
             directed := true
         ) sheds
-WHERE   EXISTS (
+WHERE r1.road_id % :thread_num = :thread_no
+AND
+EXISTS (
             SELECT  1
             FROM    neighborhood_boundary AS b
             WHERE   ST_Intersects(b.geom,r1.geom)
 )
 AND     r1.road_id = v1.road_id
 AND     v2.vert_id = sheds.node;
-
-CREATE INDEX IF NOT EXISTS idx_neighborhood_rchblrdslowstrss_b ON generated.neighborhood_reachable_roads_low_stress (base_road);
-CREATE INDEX IF NOT EXISTS idx_neighborhood_rchblrdslowstrss_t ON generated.neighborhood_reachable_roads_low_stress (target_road);
-ANALYZE generated.neighborhood_reachable_roads_low_stress (base_road,target_road);

--- a/connectivity/reachable_roads_low_stress_cleanup.sql
+++ b/connectivity/reachable_roads_low_stress_cleanup.sql
@@ -1,0 +1,8 @@
+----------------------------------------
+-- INPUTS
+-- location: neighborhood
+-- maximum network distsance: 10560 ft
+----------------------------------------
+CREATE INDEX IF NOT EXISTS idx_neighborhood_rchblrdslowstrss_b ON generated.neighborhood_reachable_roads_low_stress (base_road);
+CREATE INDEX IF NOT EXISTS idx_neighborhood_rchblrdslowstrss_t ON generated.neighborhood_reachable_roads_low_stress (target_road);
+ANALYZE generated.neighborhood_reachable_roads_low_stress (base_road,target_road);

--- a/connectivity/reachable_roads_low_stress_prep.sql
+++ b/connectivity/reachable_roads_low_stress_prep.sql
@@ -1,0 +1,13 @@
+----------------------------------------
+-- INPUTS
+-- location: neighborhood
+-- maximum network distsance: 10560 ft
+----------------------------------------
+DROP TABLE IF EXISTS generated.neighborhood_reachable_roads_low_stress;
+
+CREATE TABLE generated.neighborhood_reachable_roads_low_stress (
+    id SERIAL PRIMARY KEY,
+    base_road INT,
+    target_road INT,
+    total_cost FLOAT
+);

--- a/run_connectivity.sh
+++ b/run_connectivity.sh
@@ -25,11 +25,37 @@ psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_D
   -v nb_output_srid="${NB_OUTPUT_SRID}" \
   -f connectivity/census_block_roads.sql
 
-/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
-  -f connectivity/reachable_roads_high_stress.sql
+/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -f connectivity/reachable_roads_high_stress_prep.sql
+
+/usr/bin/time -v parallel<<EOF
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=0 -f connectivity/reachable_roads_high_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=1 -f connectivity/reachable_roads_high_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=2 -f connectivity/reachable_roads_high_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=3 -f connectivity/reachable_roads_high_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=4 -f connectivity/reachable_roads_high_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=5 -f connectivity/reachable_roads_high_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=6 -f connectivity/reachable_roads_high_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=7 -f connectivity/reachable_roads_high_stress_calc.sql
+EOF
+
+/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -f connectivity/reachable_roads_high_stress_cleanup.sql
 
 /usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
-  -f connectivity/reachable_roads_low_stress.sql
+  -f connectivity/reachable_roads_low_stress_prep.sql
+
+/usr/bin/time -v parallel<<EOF
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=0 -f connectivity/reachable_roads_low_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=1 -f connectivity/reachable_roads_low_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=2 -f connectivity/reachable_roads_low_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=3 -f connectivity/reachable_roads_low_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=4 -f connectivity/reachable_roads_low_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=5 -f connectivity/reachable_roads_low_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=6 -f connectivity/reachable_roads_low_stress_calc.sql
+psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -v thread_num=8 -v thread_no=7 -f connectivity/reachable_roads_low_stress_calc.sql
+EOF
+
+/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
+  -f connectivity/reachable_roads_low_stress_cleanup.sql
 
 /usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" \
   -v nb_boundary_buffer="${NB_BOUNDARY_BUFFER}" \


### PR DESCRIPTION
## Overview

This splits out the "reachable" roads sql from one file (`reachable_roads_high_stress.sql`) into three files:

* `..._stress_prep.sql`
* `..._stress_run.sql`
* `..._stress_cleanup.sql`

the `_run.sql` file has `thread_num` and `thread_no` parameterized so that many instances of this sql can be run simultaneously. `run_connectivity.sh` now depends on `parallel` to run 8 instances simultaneously. This will require changes to the https://github.com/azavea/pfb-network-connectivity repo.

## Testing

* Run any analysis job as before
* Verify that the results table is identical
* Verify that the parallelized analysis runs in less time

Connects https://github.com/azavea/pfb-network-connectivity/issues/44 