### PR TITLE
Add script to export analysis data

### DIFF
--- a/export_connectivity.sh
+++ b/export_connectivity.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
+# ec prefix stands for 'export connectivity'
+
 set -e
 
-cd `dirname $0`
+cd $(dirname "$0")
 
 NB_POSTGRESQL_HOST="${NB_POSTGRESQL_HOST:-127.0.0.1}"
 NB_POSTGRESQL_DB="${NB_POSTGRESQL_DB:-pfb}"
@@ -13,7 +15,7 @@ NB_OUTPUT_FILE_PREFIX="${NB_OUTPUT_FILE_PREFIX:-analysis_}"
 
 NB_OUTPUT_DIR="${1}"
 
-function usage() {
+function ec_usage() {
     echo -n \
 "
 Usage: $(basename "$0") <output_directory>
@@ -24,7 +26,7 @@ Export data from a successful run of the PeopleForBike Network Analysis to a dir
 
 This script exports the following tables:
  - neighborhood_ways as SHP
- - neighborhood_ways as GeoJSON
+ - neighborhood_ways as GeoJSON (TODO)
  - neighborhood_connected_census_blocks as SHP
  - neighborhood_overall_scores as CSV
 
@@ -39,49 +41,51 @@ NB_POSTGRESQL_PORT - Default: 4326
 
 "
 }
+
+function ec_export_table_shp() {
+    OUTPUT_DIR="$1"
+    EXPORT_TABLENAME="$2"
+
+    FILENAME="${OUTPUT_DIR}/${NB_OUTPUT_FILE_PREFIX}${EXPORT_TABLENAME}.shp"
+    pgsql2shp -h "${NB_POSTGRESQL_HOST}" \
+              -u "${NB_POSTGRESQL_USER}" \
+              -p "${NB_POSTGRESQL_PORT}" \
+              -P "${NB_POSTGRESQL_PASSWORD}" \
+              -f "${FILENAME}" \
+              "${NB_POSTGRESQL_DB}" \
+              "${EXPORT_TABLENAME}"
+}
+
+function ec_export_table_csv() {
+    OUTPUT_DIR="$1"
+    EXPORT_TABLENAME="$2"
+
+    FILENAME="${OUTPUT_DIR}/${NB_OUTPUT_FILE_PREFIX}${EXPORT_TABLENAME}.csv"
+    psql -h "${NB_POSTGRESQL_HOST}" \
+         -U "${NB_POSTGRESQL_USER}" \
+         -p "${NB_POSTGRESQL_PORT}" \
+         -d "${NB_POSTGRESQL_DB}" \
+         -c "COPY ${EXPORT_TABLENAME} TO '${FILENAME}' WITH (FORMAT CSV, HEADER)"
+}
+
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
 then
     if [ "${1:-}" = "--help" ] || [ -z "${1:-}" ]
     then
-        usage
+        ec_usage
     else
         NB_OUTPUT_DIR="${1}"
 
         # Export neighborhood_ways as SHP
-        EXPORT_TABLENAME='neighborhood_ways'
-        FILETYPE='shp'
-        FILENAME="${NB_OUTPUT_DIR}/${NB_OUTPUT_FILE_PREFIX}${EXPORT_TABLENAME}.${FILETYPE}"
-        pgsql2shp -h "${NB_POSTGRESQL_HOST}" \
-                  -u "${NB_POSTGRESQL_USER}" \
-                  -p "${NB_POSTGRESQL_PORT}" \
-                  -P "${NB_POSTGRESQL_PASSWORD}" \
-                  -f "${FILENAME}" \
-                  "${NB_POSTGRESQL_DB}" \
-                  "${EXPORT_TABLENAME}"
+        ec_export_table_shp "${NB_OUTPUT_DIR}" "neighborhood_ways"
 
         # Export neighborhood ways as GeoJSON
         # TODO: Add ogr2ogr and try again
 
         # Export neighborhood_connected_census_blocks as SHP
-        EXPORT_TABLENAME='neighborhood_connected_census_blocks'
-        FILETYPE='shp'
-        FILENAME="${NB_OUTPUT_DIR}/${NB_OUTPUT_FILE_PREFIX}${EXPORT_TABLENAME}.${FILETYPE}"
-        pgsql2shp -h "${NB_POSTGRESQL_HOST}" \
-                  -u "${NB_POSTGRESQL_USER}" \
-                  -p "${NB_POSTGRESQL_PORT}" \
-                  -P "${NB_POSTGRESQL_PASSWORD}" \
-                  -f "${FILENAME}" \
-                  "${NB_POSTGRESQL_DB}" \
-                  "${EXPORT_TABLENAME}"
+        ec_export_table_shp "${NB_OUTPUT_DIR}" "neighborhood_connected_census_blocks"
 
         # Export neighborhood_overall_scores as CSV
-        EXPORT_TABLENAME='neighborhood_overall_scores'
-        FILETYPE='csv'
-        FILENAME="${NB_OUTPUT_DIR}/${NB_OUTPUT_FILE_PREFIX}${EXPORT_TABLENAME}.${FILETYPE}"
-        psql -h "${NB_POSTGRESQL_HOST}" \
-             -U "${NB_POSTGRESQL_USER}" \
-             -p "${NB_POSTGRESQL_PORT}" \
-             -d "${NB_POSTGRESQL_DB}" \
-             -c "COPY ${EXPORT_TABLENAME} TO '${FILENAME}' WITH (FORMAT CSV, HEADER)"
+        ec_export_table_csv "${NB_OUTPUT_DIR}" "neighborhood_overall_scores"
     fi
 fi

--- a/export_connectivity.sh
+++ b/export_connectivity.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd `dirname $0`
+
+NB_POSTGRESQL_HOST="${NB_POSTGRESQL_HOST:-127.0.0.1}"
+NB_POSTGRESQL_DB="${NB_POSTGRESQL_DB:-pfb}"
+NB_POSTGRESQL_USER="${NB_POSTGRESQL_USER:-gis}"
+NB_POSTGRESQL_PASSWORD="${NB_POSTGRESQL_PASSWORD:-gis}"
+NB_POSTGRESQL_PORT="${NB_POSTGRESQL_PORT:-5432}"
+NB_OUTPUT_FILE_PREFIX="${NB_OUTPUT_FILE_PREFIX:-analysis_}"
+
+NB_OUTPUT_DIR="${1}"
+
+function usage() {
+    echo -n \
+"
+Usage: $(basename "$0") <output_directory>
+
+Export data from a successful run of the PeopleForBike Network Analysis to a directory on disk.
+
+<output_directory> must be an absolute path (pgsql COPY doesn't support relative paths)
+
+This script exports the following tables:
+ - neighborhood_ways as SHP
+ - neighborhood_ways as GeoJSON
+ - neighborhood_connected_census_blocks as SHP
+ - neighborhood_overall_scores as CSV
+
+Optional ENV vars:
+
+NB_OUTPUT_FILE_PREFIX - Default: 'analysis_'
+NB_POSTGRESQL_HOST - Default: 127.0.0.1
+NB_POSTGRESQL_DB - Default: pfb
+NB_POSTGRESQL_USER - Default: gis
+NB_POSTGRESQL_PASSWORD - Default: gis
+NB_POSTGRESQL_PORT - Default: 4326
+
+"
+}
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ] || [ -z "${1:-}" ]
+    then
+        usage
+    else
+        NB_OUTPUT_DIR="${1}"
+
+        # Export neighborhood_ways as SHP
+        EXPORT_TABLENAME='neighborhood_ways'
+        FILETYPE='shp'
+        FILENAME="${NB_OUTPUT_DIR}/${NB_OUTPUT_FILE_PREFIX}${EXPORT_TABLENAME}.${FILETYPE}"
+        pgsql2shp -h "${NB_POSTGRESQL_HOST}" \
+                  -u "${NB_POSTGRESQL_USER}" \
+                  -p "${NB_POSTGRESQL_PORT}" \
+                  -P "${NB_POSTGRESQL_PASSWORD}" \
+                  -f "${FILENAME}" \
+                  "${NB_POSTGRESQL_DB}" \
+                  "${EXPORT_TABLENAME}"
+
+        # Export neighborhood ways as GeoJSON
+        # TODO: Add ogr2ogr and try again
+
+        # Export neighborhood_connected_census_blocks as SHP
+        EXPORT_TABLENAME='neighborhood_connected_census_blocks'
+        FILETYPE='shp'
+        FILENAME="${NB_OUTPUT_DIR}/${NB_OUTPUT_FILE_PREFIX}${EXPORT_TABLENAME}.${FILETYPE}"
+        pgsql2shp -h "${NB_POSTGRESQL_HOST}" \
+                  -u "${NB_POSTGRESQL_USER}" \
+                  -p "${NB_POSTGRESQL_PORT}" \
+                  -P "${NB_POSTGRESQL_PASSWORD}" \
+                  -f "${FILENAME}" \
+                  "${NB_POSTGRESQL_DB}" \
+                  "${EXPORT_TABLENAME}"
+
+        # Export neighborhood_overall_scores as CSV
+        EXPORT_TABLENAME='neighborhood_overall_scores'
+        FILETYPE='csv'
+        FILENAME="${NB_OUTPUT_DIR}/${NB_OUTPUT_FILE_PREFIX}${EXPORT_TABLENAME}.${FILETYPE}"
+        psql -h "${NB_POSTGRESQL_HOST}" \
+             -U "${NB_POSTGRESQL_USER}" \
+             -p "${NB_POSTGRESQL_PORT}" \
+             -d "${NB_POSTGRESQL_DB}" \
+             -c "COPY ${EXPORT_TABLENAME} TO '${FILENAME}' WITH (FORMAT CSV, HEADER)"
+    fi
+fi


### PR DESCRIPTION
## Overview

Adds an additional script to the analysis that can be run afterwards to export the analysis data to a local directory.

## Demo

<img width="1309" alt="screen shot 2017-02-04 at 17 06 23" src="https://cloud.githubusercontent.com/assets/1818302/22621907/b37dbec2-eafc-11e6-9e3b-a5ffe92aa026.png">


### Notes

I was unable to get `ogr2ogr` installed via the ubuntugis PPA to do the direct psql -> geojson export. The `gdal-bin` package and the `postgresql-9.6-postgis-2.3` packages conflict on the version of `libgdal` that they expect. I can continue to investigate this but it might be better to save for a separate task.

Once this script is merged, I'll submit a PR to pfb-network-connectivity that adds this script to the 'Running the Analysis' section of the README.

## Testing

- Run any analysis
- Run this new script to export data: `./pfb-analysis/export_connectivity.sh <path to output dir that exists>`
- View CSV data and SHP data

Connects #14 