### PR TITLE
Feature/calcuate adjacent blocks

### DIFF
--- a/connectivity/reachable_roads_high_stress_calc.sql
+++ b/connectivity/reachable_roads_high_stress_calc.sql
@@ -11,25 +11,17 @@ INSERT INTO generated.neighborhood_reachable_roads_high_stress (
 SELECT  r1.road_id,
         v2.road_id,
         sheds.agg_cost
-FROM    neighborhood_ways r1
+FROM    neighborhood_ways_bounded r1
         INNER JOIN neighborhood_ways_net_vert v1 ON (r1.road_id = v1.road_id),
         pgr_drivingDistance('
-            SELECT     nl.link_id AS id,
-                       nl.source_vert AS source,
-                       nl.target_vert AS target,
-                       nl.link_cost AS cost
-            FROM       neighborhood_ways_net_link AS nl
-            INNER JOIN neighborhood_boundary AS nb
-            ON         ST_Intersects(nl.geom, nb.geom)',
+            SELECT  link_id AS id,
+                    source_vert AS source,
+                    target_vert AS target,
+                    link_cost AS cost
+            FROM    neighborhood_ways_net_link_bounded',
             v1.vert_id,
             10560,
             directed := true
         ) sheds
         INNER JOIN neighborhood_ways_net_vert v2 ON (v2.vert_id = sheds.node)
-WHERE r1.road_id % :thread_num = :thread_no
-AND
-EXISTS (
-            SELECT  1
-            FROM    neighborhood_boundary AS b
-            WHERE   ST_Intersects(b.geom, r1.geom)
-);
+WHERE r1.road_id % :thread_num = :thread_no;

--- a/connectivity/reachable_roads_high_stress_calc.sql
+++ b/connectivity/reachable_roads_high_stress_calc.sql
@@ -14,11 +14,13 @@ SELECT  r1.road_id,
 FROM    neighborhood_ways r1
         INNER JOIN neighborhood_ways_net_vert v1 ON (r1.road_id = v1.road_id),
         pgr_drivingDistance('
-            SELECT  link_id AS id,
-                    source_vert AS source,
-                    target_vert AS target,
-                    link_cost AS cost
-            FROM    neighborhood_ways_net_link',
+            SELECT     nl.link_id AS id,
+                       nl.source_vert AS source,
+                       nl.target_vert AS target,
+                       nl.link_cost AS cost
+            FROM       neighborhood_ways_net_link AS nl
+            INNER JOIN neighborhood_boundary_buffered AS nb
+            ON         ST_Intersects(nl.geom, nb.geom)',
             v1.vert_id,
             10560,
             directed := true

--- a/connectivity/reachable_roads_high_stress_calc.sql
+++ b/connectivity/reachable_roads_high_stress_calc.sql
@@ -11,9 +11,8 @@ INSERT INTO generated.neighborhood_reachable_roads_high_stress (
 SELECT  r1.road_id,
         v2.road_id,
         sheds.agg_cost
-FROM    neighborhood_ways r1,
-        neighborhood_ways_net_vert v1,
-        neighborhood_ways_net_vert v2,
+FROM    neighborhood_ways r1
+        INNER JOIN neighborhood_ways_net_vert v1 ON (r1.road_id = v1.road_id),
         pgr_drivingDistance('
             SELECT  link_id AS id,
                     source_vert AS source,
@@ -24,13 +23,11 @@ FROM    neighborhood_ways r1,
             10560,
             directed := true
         ) sheds
+        INNER JOIN neighborhood_ways_net_vert v2 ON (v2.vert_id = sheds.node)
 WHERE r1.road_id % :thread_num = :thread_no
 AND
 EXISTS (
             SELECT  1
             FROM    neighborhood_boundary AS b
-            WHERE   ST_Intersects(b.geom,r1.geom)
-)
-AND     r1.road_id = v1.road_id
-AND     v2.vert_id = sheds.node;
-
+            WHERE   ST_Intersects(b.geom, r1.geom)
+);

--- a/connectivity/reachable_roads_high_stress_calc.sql
+++ b/connectivity/reachable_roads_high_stress_calc.sql
@@ -19,7 +19,7 @@ FROM    neighborhood_ways r1
                        nl.target_vert AS target,
                        nl.link_cost AS cost
             FROM       neighborhood_ways_net_link AS nl
-            INNER JOIN neighborhood_boundary_buffered AS nb
+            INNER JOIN neighborhood_boundary AS nb
             ON         ST_Intersects(nl.geom, nb.geom)',
             v1.vert_id,
             10560,

--- a/connectivity/reachable_roads_low_stress_calc.sql
+++ b/connectivity/reachable_roads_low_stress_calc.sql
@@ -11,26 +11,18 @@ INSERT INTO generated.neighborhood_reachable_roads_low_stress (
 SELECT  r1.road_id,
         v2.road_id,
         sheds.agg_cost
-FROM    neighborhood_ways r1
+FROM    neighborhood_ways_bounded r1
         INNER JOIN neighborhood_ways_net_vert v1 ON (r1.road_id = v1.road_id),
         pgr_drivingDistance('
-            SELECT     nl.link_id AS id,
-                       nl.source_vert AS source,
-                       nl.target_vert AS target,
-                       nl.link_cost AS cost
-            FROM       neighborhood_ways_net_link AS nl
-            INNER JOIN neighborhood_boundary AS nb
-            ON         ST_Intersects(nl.geom, nb.geom)
-            WHERE      link_stress = 1',
+            SELECT  link_id AS id,
+                    source_vert AS source,
+                    target_vert AS target,
+                    link_cost AS cost
+            FROM    neighborhood_ways_net_link_bounded
+            WHERE   link_stress = 1',
             v1.vert_id,
             10560,
             directed := true
         ) sheds
         INNER JOIN neighborhood_ways_net_vert v2 ON (v2.vert_id = sheds.node)
-WHERE r1.road_id % :thread_num = :thread_no
-AND
-EXISTS (
-            SELECT  1
-            FROM    neighborhood_boundary AS b
-            WHERE   ST_Intersects(b.geom, r1.geom)
-);
+WHERE r1.road_id % :thread_num = :thread_no;

--- a/connectivity/reachable_roads_low_stress_calc.sql
+++ b/connectivity/reachable_roads_low_stress_calc.sql
@@ -19,7 +19,7 @@ FROM    neighborhood_ways r1
                        nl.target_vert AS target,
                        nl.link_cost AS cost
             FROM       neighborhood_ways_net_link AS nl
-            INNER JOIN neighborhood_boundary_buffered AS nb
+            INNER JOIN neighborhood_boundary AS nb
             ON         ST_Intersects(nl.geom, nb.geom)
             WHERE      link_stress = 1',
             v1.vert_id,

--- a/connectivity/reachable_roads_low_stress_calc.sql
+++ b/connectivity/reachable_roads_low_stress_calc.sql
@@ -11,9 +11,8 @@ INSERT INTO generated.neighborhood_reachable_roads_low_stress (
 SELECT  r1.road_id,
         v2.road_id,
         sheds.agg_cost
-FROM    neighborhood_ways r1,
-        neighborhood_ways_net_vert v1,
-        neighborhood_ways_net_vert v2,
+FROM    neighborhood_ways r1
+        INNER JOIN neighborhood_ways_net_vert v1 ON (r1.road_id = v1.road_id),
         pgr_drivingDistance('
             SELECT  link_id AS id,
                     source_vert AS source,
@@ -25,12 +24,11 @@ FROM    neighborhood_ways r1,
             10560,
             directed := true
         ) sheds
+        INNER JOIN neighborhood_ways_net_vert v2 ON (v2.vert_id = sheds.node)
 WHERE r1.road_id % :thread_num = :thread_no
 AND
 EXISTS (
             SELECT  1
             FROM    neighborhood_boundary AS b
-            WHERE   ST_Intersects(b.geom,r1.geom)
-)
-AND     r1.road_id = v1.road_id
-AND     v2.vert_id = sheds.node;
+            WHERE   ST_Intersects(b.geom, r1.geom)
+);

--- a/connectivity/reachable_roads_low_stress_calc.sql
+++ b/connectivity/reachable_roads_low_stress_calc.sql
@@ -14,12 +14,14 @@ SELECT  r1.road_id,
 FROM    neighborhood_ways r1
         INNER JOIN neighborhood_ways_net_vert v1 ON (r1.road_id = v1.road_id),
         pgr_drivingDistance('
-            SELECT  link_id AS id,
-                    source_vert AS source,
-                    target_vert AS target,
-                    link_cost AS cost
-            FROM    neighborhood_ways_net_link
-            WHERE   link_stress = 1',
+            SELECT     nl.link_id AS id,
+                       nl.source_vert AS source,
+                       nl.target_vert AS target,
+                       nl.link_cost AS cost
+            FROM       neighborhood_ways_net_link AS nl
+            INNER JOIN neighborhood_boundary_buffered AS nb
+            ON         ST_Intersects(nl.geom, nb.geom)
+            WHERE      link_stress = 1',
             v1.vert_id,
             10560,
             directed := true

--- a/connectivity/reachable_roads_prep.sql
+++ b/connectivity/reachable_roads_prep.sql
@@ -1,0 +1,25 @@
+DROP TABLE IF EXISTS neighborhood_ways_bounded;
+
+SELECT ways.*
+INTO neighborhood_ways_bounded
+FROM neighborhood_ways AS ways
+INNER JOIN neighborhood_boundary AS bounds
+ON (ST_Intersects(bounds.geom, ways.geom));
+
+CREATE INDEX idx_neighborhood_ways_bounded_road_id ON neighborhood_ways_bounded (road_id);
+ANALYZE neighborhood_ways (road_id);
+
+DROP TABLE IF EXISTS neighborhood_ways_net_link_bounded;
+
+SELECT net_link.*
+INTO neighborhood_ways_net_link_bounded
+FROM neighborhood_ways_net_link AS net_link
+INNER JOIN neighborhood_boundary AS bounds
+ON (ST_Intersects(bounds.geom, net_link.geom));
+
+CREATE INDEX idx_neighborhood_net_link_bounded_road_id ON neighborhood_ways_bounded (road_id);
+ANALYZE neighborhood_ways (road_id);
+
+CREATE INDEX idx_neighborhood_ways_net_vert_road_id ON neighborhood_ways_net_vert (road_id);
+CREATE INDEX idx_neighborhood_ways_net_vert_vert_id ON neighborhood_ways_net_vert (vert_id);
+ANALYZE neighborhood_ways_net_vert (road_id, vert_id);

--- a/prepare_tables.sql
+++ b/prepare_tables.sql
@@ -73,6 +73,11 @@ ALTER TABLE neighborhood_ways ADD COLUMN ft_int_stress INT;
 ALTER TABLE neighborhood_ways ADD COLUMN tf_seg_stress INT;
 ALTER TABLE neighborhood_ways ADD COLUMN tf_int_stress INT;
 
+-- buffer neighborhood boundary to max travelshed distance
+SELECT ST_Buffer(b.geom, 10560) AS geom INTO neighborhood_boundary_buffered FROM neighborhood_boundary b;
+CREATE INDEX idx_neighborhood_boundary_buffered_geom ON neighborhood_boundary_buffered USING GIST (geom);
+ANALYZE neighborhood_boundary_buffered (geom);
+
 -- indexes
 CREATE INDEX idx_neighborhood_ways_osm ON neighborhood_ways (osm_id);
 CREATE INDEX idx_neighborhood_ways_ints_osm ON neighborhood_ways_intersections (osm_id);

--- a/prepare_tables.sql
+++ b/prepare_tables.sql
@@ -76,9 +76,12 @@ ALTER TABLE neighborhood_ways ADD COLUMN tf_int_stress INT;
 -- indexes
 CREATE INDEX idx_neighborhood_ways_osm ON neighborhood_ways (osm_id);
 CREATE INDEX idx_neighborhood_ways_ints_osm ON neighborhood_ways_intersections (osm_id);
+CREATE INDEX idx_neighborhood_ways_geom ON neighborhood_ways USING GIST (geom);
+CREATE INDEX idx_neighborhood_boundary_geom ON neighborhood_boundary USING GIST (geom);
 CREATE INDEX idx_neighborhood_fullways ON neighborhood_osm_full_line (osm_id);
 CREATE INDEX idx_neighborhood_fullpoints ON neighborhood_osm_full_point (osm_id);
-ANALYZE neighborhood_ways (osm_id,geom);
+ANALYZE neighborhood_ways (osm_id, geom);
+ANALYZE neighborhood_boundary (geom);
 ANALYZE neighborhood_cycwys_ways (the_geom);
 ANALYZE neighborhood_ways_intersections (osm_id);
 ANALYZE neighborhood_osm_full_line (osm_id);

--- a/prepare_tables.sql
+++ b/prepare_tables.sql
@@ -73,11 +73,6 @@ ALTER TABLE neighborhood_ways ADD COLUMN ft_int_stress INT;
 ALTER TABLE neighborhood_ways ADD COLUMN tf_seg_stress INT;
 ALTER TABLE neighborhood_ways ADD COLUMN tf_int_stress INT;
 
--- buffer neighborhood boundary to max travelshed distance
-SELECT ST_Buffer(b.geom, 10560) AS geom INTO neighborhood_boundary_buffered FROM neighborhood_boundary b;
-CREATE INDEX idx_neighborhood_boundary_buffered_geom ON neighborhood_boundary_buffered USING GIST (geom);
-ANALYZE neighborhood_boundary_buffered (geom);
-
 -- indexes
 CREATE INDEX idx_neighborhood_ways_osm ON neighborhood_ways (osm_id);
 CREATE INDEX idx_neighborhood_ways_ints_osm ON neighborhood_ways_intersections (osm_id);

--- a/run_connectivity.sh
+++ b/run_connectivity.sh
@@ -25,6 +25,8 @@ psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_D
   -v nb_output_srid="${NB_OUTPUT_SRID}" \
   -f connectivity/census_block_roads.sql
 
+/usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -f connectivity/reachable_roads_prep.sql
+
 /usr/bin/time -v psql -h "${NB_POSTGRESQL_HOST}" -U "${NB_POSTGRESQL_USER}" -d "${NB_POSTGRESQL_DB}" -f connectivity/reachable_roads_high_stress_prep.sql
 
 /usr/bin/time -v parallel<<EOF


### PR DESCRIPTION
Connects azavea/pfb-network-connectivity#45.

Improve performance of stress calculation queries by creating intermediate tables filtered to the neighborhood bounds, rather than filtering within the query.

For Boulder, results in ~10x improvement in calculation time; removes almost 3/4 of the edges sent to `pgr_drivingDistance`.