### PR TITLE
Update the README for deprecation of this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# DEPRECATED
+
+This was pulled into [azavea/pfb-network-connectivity](https://github.com/azavea/pfb-network-connectivity) at [8561f90ba](https://github.com/azavea/pfb-network-connectivity/commit/8561f90ba4019f5fac49c297155a85742cfdd974).
+
+Further work should be done over there.
+
+---
+
 # pfb
 
 ## Docker


### PR DESCRIPTION
https://github.com/azavea/pfb-network-connectivity/pull/71 merged this work into that repo, so this repo is closed for business (historical reference only, should probably delete in a month or three).